### PR TITLE
fix issue #19

### DIFF
--- a/src/renderer/components/Editor.vue
+++ b/src/renderer/components/Editor.vue
@@ -147,7 +147,6 @@ export default {
           self.setEditor(content)
           self.setPath(path)
         } else if (err.code !== ERR_USER_CANCEL) {
-          console.log(err)
           self.openDialog('error', err.toString())
         }
       })

--- a/src/renderer/components/Editor.vue
+++ b/src/renderer/components/Editor.vue
@@ -20,6 +20,7 @@
 
 <script>
 import fs from '../modules/Filesystem.js'
+import { ERR_USER_CANCEL } from '../modules/Errors'
 const Markdown = require('../modules/markdown.js')
 const Editor = require('../modules/editor.js')
 const Menu = require('../modules/menu.js')
@@ -145,7 +146,8 @@ export default {
         if (err === null) {
           self.setEditor(content)
           self.setPath(path)
-        } else {
+        } else if (err.code !== ERR_USER_CANCEL) {
+          console.log(err)
           self.openDialog('error', err.toString())
         }
       })
@@ -228,7 +230,9 @@ export default {
           return true
         }
       } catch (e) {
-        self.openDialog('error', e)
+        if (e.code !== ERR_USER_CANCEL) {
+          self.openDialog('error', e)
+        }
         return false
       }
 

--- a/src/renderer/components/EncryptKeyPrompt.vue
+++ b/src/renderer/components/EncryptKeyPrompt.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-  const { ipcRenderer } = require('electron')
+  import { ipcRenderer } from 'electron'
   export default {
     name: 'mii-encrypt-key-prompt',
     data () {
@@ -20,7 +20,7 @@
         ipcRenderer.sendSync('set-key', this.key)
       },
       cancel () {
-        ipcRenderer.sendSync('set-key', '')
+        ipcRenderer.sendSync('set-key', null)
       }
     }
   }

--- a/src/renderer/components/Toolbar.vue
+++ b/src/renderer/components/Toolbar.vue
@@ -5,11 +5,11 @@
 </template>
 
 <script>
-var fs = require('../modules/Filesystem')
+import fs from '../modules/Filesystem'
+import { ERR_USER_CANCEL } from '../modules/Errors'
 var remote = require('electron').remote
 var browserWindow = remote.BrowserWindow
 var focusedWindow = browserWindow.getFocusedWindow()
-
 export default {
   name: 'mii-toolbar',
   data () {
@@ -125,7 +125,7 @@ export default {
           miiEditor.editor.markClean()
           miiEditor.editor.clearHistory()
           miiEditor.updateButtonStatus()
-        } else {
+        } else if (err.code !== ERR_USER_CANCEL) {
           self.openDialog('error', err.toString())
         }
       })
@@ -169,7 +169,9 @@ export default {
           return true
         }
       } catch (e) {
-        self.openDialog('error', e)
+        if (e.code !== ERR_USER_CANCEL)) {
+          self.openDialog('error', e)
+        }
         return false
       }
     },

--- a/src/renderer/components/Toolbar.vue
+++ b/src/renderer/components/Toolbar.vue
@@ -169,7 +169,7 @@ export default {
           return true
         }
       } catch (e) {
-        if (e.code !== ERR_USER_CANCEL)) {
+        if (e.code !== ERR_USER_CANCEL) {
           self.openDialog('error', e)
         }
         return false

--- a/src/renderer/modules/Encryptor.js
+++ b/src/renderer/modules/Encryptor.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const crypto = require('crypto')
+import crypto from 'crypto'
+import { DecryptFailError } from './Errors'
 
 function Encryptor () {
   this.info = {
@@ -35,7 +36,7 @@ Encryptor.prototype.decrypt = function (key, raw, iv) {
   try {
     return Buffer.concat([decipher.update(raw), decipher.final()])
   } catch (err) {
-    throw new Error('Decrypt Fail: Wrong Password')
+    throw new DecryptFailError('Wrong Password')
   }
 }
 
@@ -56,4 +57,4 @@ Encryptor.prototype.listHashes = function () {
   return crypto.getHashes()
 }
 
-module.exports = new Encryptor()
+export default new Encryptor()

--- a/src/renderer/modules/Errors.js
+++ b/src/renderer/modules/Errors.js
@@ -1,0 +1,36 @@
+const ERR_USER_CANCEL = -100
+const ERR_ENCRYPT_FAIL = -101
+const ERR_DECRYPT_FAIL = -102
+
+class UserCancelError extends Error {
+  constructor () {
+    super('User Canceled.')
+    this.name = 'UserCancelError'
+    this.code = ERR_USER_CANCEL
+  }
+}
+
+class EncryptFailError extends Error {
+  constructor (reason) {
+    super(reason)
+    this.name = 'EncryptFailError'
+    this.code = ERR_ENCRYPT_FAIL
+  }
+}
+
+class DecryptFailError extends Error {
+  constructor (reason) {
+    super(reason)
+    this.name = 'DecryptFailError'
+    this.code = ERR_DECRYPT_FAIL
+  }
+}
+
+export {
+  ERR_USER_CANCEL,
+  UserCancelError,
+  ERR_ENCRYPT_FAIL,
+  EncryptFailError,
+  ERR_DECRYPT_FAIL,
+  DecryptFailError
+}


### PR DESCRIPTION
This pull request mainly fix #19. The biggest change is I add Errors.js for defining custom errors. The better way to check error type and do the proper job is useing instanceof or error code instead of err.toString or message. 

However, I have to mention that instanceof doesn't work properly with class which created by es6 "class extends" under current develop environment, but it works fine in pure nodejs v8.11.2, so it should be an issue of webpack/babel or some magic tools.

And I see different style within modules, such as export/import/require and const/var etc. I try to follow it but it just confused me. My personal opinion is using ES6 style such as import/export instead of module.exports/require and class/extends instead of function. We need to talk about that and  unite all of them.

Oh, I was going to fix this much earlier, but I cannot help playing with my cat. Sorry about that :P