### PR TITLE
Apply vue-material on KeyPrompt and a few of improvement

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -61,8 +61,8 @@ ipcMain.on('ask-key', askKeyEvent => {
   });
   askKeyPrompt.loadURL(
     process.env.NODE_ENV === 'development'
-      ? 'http://localhost:9080/#/ask-encrypt-key'
-      : `file://${__dirname}/index.html#ask-encrypt-key`,
+      ? 'http://localhost:9080/#/ask-key'
+      : `file://${__dirname}/index.html#ask-key`,
   );
   ipcMain.once('set-key', (setKeyEvent, setKeyArgu) => {
     askKeyPrompt.close();

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow } from 'electron';
 
 /**
  * Set `__static` path to static files in production
@@ -48,25 +48,4 @@ app.on('activate', () => {
   if (mainWindow === null) {
     createWindow();
   }
-});
-
-ipcMain.on('ask-key', askKeyEvent => {
-  let askKeyPrompt = new BrowserWindow({
-    width: 350,
-    height: 100,
-    parent: mainWindow,
-    modal: true,
-    frame: false,
-    resizable: false,
-  });
-  askKeyPrompt.loadURL(
-    process.env.NODE_ENV === 'development'
-      ? 'http://localhost:9080/#/ask-key'
-      : `file://${__dirname}/index.html#ask-key`,
-  );
-  ipcMain.once('set-key', (setKeyEvent, setKeyArgu) => {
-    askKeyPrompt.close();
-    askKeyPrompt = null;
-    askKeyEvent.sender.send('reply-ask-key', setKeyArgu);
-  });
 });

--- a/src/renderer/components/Editor.vue
+++ b/src/renderer/components/Editor.vue
@@ -156,7 +156,7 @@ export default {
             // 編集済み：合保存するか確認ダイアログを表示する
             self.saveModifyFile();
             if (fs.shouldEncrypt(path)) {
-              self.openKeyPrompt('openFile', path);
+              self.openKeyPrompt('open', path);
             } else {
               self.readFile(path);
             }
@@ -233,7 +233,7 @@ export default {
         this.setPath(savePath);
         let result;
         if (fs.shouldEncrypt(savePath)) {
-          this.openKeyPrompt('saveAs', savePath);
+          this.openKeyPrompt('save', savePath);
         } else {
           result = this.writeFile();
         }
@@ -320,9 +320,9 @@ export default {
       // Currently, only openFile and saveAs need user to enter key.
       // When openFile, fs use cached key which is set when readFile success,
       // so call writeFile instead of openKeyPrompt when save a encrypted file.
-      if (name === 'openFile') {
+      if (name === 'open') {
         this.readFile(path);
-      } else if (name === 'saveAs') {
+      } else if (name === 'save') {
         // the linter force me to use this style ...
         fs.writeFile(
           this.path,

--- a/src/renderer/components/Editor.vue
+++ b/src/renderer/components/Editor.vue
@@ -25,6 +25,7 @@ import editorOptions from '@/modules/editor.js';
 import Menu from '@/modules/menu.js';
 import DropField from '@/components/DropField';
 import KeyPrompt from '@/components/KeyPrompt';
+import { UnexpectedStateError } from '@/modules/Errors';
 
 export default {
   name: 'MiiEditor',
@@ -336,7 +337,8 @@ export default {
           key,
         );
       } else {
-        // TODO
+        const err = new UnexpectedStateError('crypt.op.name', name);
+        this.openDialog('error', err.toString());
       }
       this.$store.dispatch('setCryptOP', { name: null, path: null });
     },

--- a/src/renderer/components/Editor.vue
+++ b/src/renderer/components/Editor.vue
@@ -11,6 +11,7 @@
       <div class="markdown-body" v-html="input"/>
     </div>
     <DropField/>
+    <KeyPrompt @done="onKeyPromptDone"/>
   </div>
 </template>
 
@@ -18,17 +19,18 @@
 import { mapState } from 'vuex';
 import { debounce } from 'lodash';
 import fs from '@/modules/Filesystem.js';
-import { ERR_USER_CANCEL } from '@/modules/Errors';
 import { initMarkdown } from '@/modules/markdown.js';
 import { getSavePath, getSelectedResult } from '@/modules/dialog.js';
 import editorOptions from '@/modules/editor.js';
 import Menu from '@/modules/menu.js';
 import DropField from '@/components/DropField';
+import KeyPrompt from '@/components/KeyPrompt';
 
 export default {
   name: 'MiiEditor',
   components: {
     DropField,
+    KeyPrompt,
   },
   data() {
     return {
@@ -152,7 +154,11 @@ export default {
 
             // 編集済み：合保存するか確認ダイアログを表示する
             self.saveModifyFile();
-            self.readFile(path);
+            if (fs.shouldEncrypt(path)) {
+              self.openKeyPrompt('openFile', path);
+            } else {
+              self.readFile(path);
+            }
           }
         },
       );
@@ -177,7 +183,7 @@ export default {
           self.setPath(path);
           self.editor.markClean();
           self.editor.clearHistory();
-        } else if (err.code !== ERR_USER_CANCEL) {
+        } else {
           self.openDialog('error', err.toString());
         }
       });
@@ -224,7 +230,13 @@ export default {
 
       if (savePath) {
         this.setPath(savePath);
-        let result = this.writeFile();
+        let result;
+        if (fs.shouldEncrypt(savePath)) {
+          this.openKeyPrompt('saveAs', savePath);
+        } else {
+          result = this.writeFile();
+        }
+
         if (result) {
           this.editor.markClean();
           this.editor.clearHistory();
@@ -243,9 +255,7 @@ export default {
           return true;
         }
       } catch (e) {
-        if (e.code !== ERR_USER_CANCEL) {
-          this.openDialog('error', e);
-        }
+        this.openDialog('error', e);
         return false;
       }
 
@@ -292,6 +302,43 @@ export default {
           }
         }
       });
+    },
+    openKeyPrompt(name = null, path = null) {
+      this.$store.dispatch('setCryptEnable', true);
+      // Because the "key input" is an async behavior,
+      // we need to remember what to do after it's done.
+      // Any better method ?
+      this.$store.dispatch('setCryptOP', { name: name, path: path });
+    },
+    onKeyPromptDone(key) {
+      if (key === null || key === '') {
+        return;
+      }
+      const name = this.$store.state.Editor.crypt.op.name;
+      const path = this.$store.state.Editor.crypt.op.path;
+      // Currently, only openFile and saveAs need user to enter key.
+      // When openFile, fs use cached key which is set when readFile success,
+      // so call writeFile instead of openKeyPrompt when save a encrypted file.
+      if (name === 'openFile') {
+        this.readFile(path);
+      } else if (name === 'saveAs') {
+        // the linter force me to use this style ...
+        fs.writeFile(
+          this.path,
+          this.code,
+          err => {
+            if (err) {
+              this.openDialog('error', err.toString());
+            } else {
+              fs.updateKey(key);
+            }
+          },
+          key,
+        );
+      } else {
+        // TODO
+      }
+      this.$store.dispatch('setCryptOP', { name: null, path: null });
     },
   },
 };

--- a/src/renderer/components/KeyPrompt.vue
+++ b/src/renderer/components/KeyPrompt.vue
@@ -3,9 +3,8 @@
     <md-dialog-prompt
       :md-active.sync="enable"
       v-model="key"
-      md-title="Password is required"
+      :md-title.sync="title"
       md-input-maxlength="30"
-      md-input-placeholder="..."
       @md-confirm="done"
       @md-cancel="cancel" />
   </div>
@@ -14,6 +13,11 @@
 <script>
 export default {
   name: 'KeyPrompt',
+  data: function() {
+    return {
+      title: '',
+    };
+  },
   computed: {
     enable: {
       get: function() {
@@ -30,6 +34,13 @@ export default {
       set: function(v) {
         this.$store.dispatch('setCryptKey', v);
       },
+    },
+  },
+  watch: {
+    enable: function() {
+      const fname = this.$store.state.Editor.crypt.op.path.split('/').pop();
+      const opname = this.$store.state.Editor.crypt.op.name;
+      this.title = 'Password is required to ' + opname + ' ' + fname;
     },
   },
   methods: {

--- a/src/renderer/components/KeyPrompt.vue
+++ b/src/renderer/components/KeyPrompt.vue
@@ -8,7 +8,7 @@
 
 <script>
 export default {
-  name: 'MiiEncryptKeyPrompt',
+  name: 'KeyPrompt',
   data() {
     return {
       key: '',

--- a/src/renderer/components/KeyPrompt.vue
+++ b/src/renderer/components/KeyPrompt.vue
@@ -1,13 +1,21 @@
 <template>
   <div>
-    <md-dialog-prompt
-      :md-active.sync="enable"
-      v-model="key"
-      :md-title.sync="title"
-      md-input-maxlength="30"
-      md-input-placeholder="Password is required"
-      @md-confirm="done"
-      @md-cancel="cancel" />
+    <md-dialog :md-active.sync="enable">
+      <md-dialog-title>{{ title }}</md-dialog-title>
+      <md-dialog-content>
+        <md-field>
+          <label>Password is required</label>
+          <md-input
+            v-model="key"
+            maxlength="50"
+            type="password"/>
+        </md-field>
+      </md-dialog-content>
+      <md-dialog-actions>
+        <md-button class="md-primary" @click="done">OK</md-button>
+        <md-button class="md-primary" @click="cancel">Cancel</md-button>
+      </md-dialog-actions>
+    </md-dialog>
   </div>
 </template>
 
@@ -54,9 +62,11 @@ export default {
   },
   methods: {
     done() {
+      this.enable = false;
       this.$emit('done', this.key);
     },
     cancel() {
+      this.enable = false;
       this.$emit('done', null);
     },
   },

--- a/src/renderer/components/KeyPrompt.vue
+++ b/src/renderer/components/KeyPrompt.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <md-dialog :md-active.sync="enable">
+    <md-dialog :md-active.sync="enable" @md-opened="onOpen">
       <md-dialog-title>{{ title }}</md-dialog-title>
       <md-dialog-content>
         <md-field>
@@ -45,8 +45,16 @@ export default {
       },
     },
   },
-  watch: {
-    enable: function() {
+  methods: {
+    done() {
+      this.enable = false;
+      this.$emit('done', this.key);
+    },
+    cancel() {
+      this.enable = false;
+      this.$emit('done', null);
+    },
+    onOpen() {
       let fname = this.$store.state.Editor.crypt.op.path;
       let opname = this.$store.state.Editor.crypt.op.name;
 
@@ -56,18 +64,8 @@ export default {
         this.title = opname + ' ' + fname;
       } else {
         // Unexpected situation
-        this.title = '';
+        this.title = 'Unkown operation';
       }
-    },
-  },
-  methods: {
-    done() {
-      this.enable = false;
-      this.$emit('done', this.key);
-    },
-    cancel() {
-      this.enable = false;
-      this.$emit('done', null);
     },
   },
 };

--- a/src/renderer/components/KeyPrompt.vue
+++ b/src/renderer/components/KeyPrompt.vue
@@ -1,41 +1,48 @@
 <template>
   <div>
-    <input v-model="key" type="password" placeholder="Enter key...">
-    <input :disabled="key.trim().length === 0" type="button" value="⮐" @click="ok">
-    <input type="button" value="X" @click="cancel">
+    <md-dialog-prompt
+      :md-active.sync="enable"
+      v-model="key"
+      md-title="Unlock "
+      md-input-maxlength="30"
+      md-input-placeholder="Password here."
+      md-confirm-text="Done"
+      @md-confirm="done"
+      @md-cancel="cancel" />
   </div>
 </template>
 
 <script>
 export default {
   name: 'KeyPrompt',
-  data() {
-    return {
-      key: '',
-    };
+  computed: {
+    enable: {
+      get: function() {
+        return this.$store.state.Editor.crypt.enable;
+      },
+      set: function(v) {
+        this.$store.dispatch('setCryptEnable', v);
+      },
+    },
+    key: {
+      get: function() {
+        return this.$store.state.Editor.crypt.key;
+      },
+      set: function(v) {
+        this.$store.dispatch('setCryptKey', v);
+      },
+    },
   },
   methods: {
-    ok() {
-      this.$electron.ipcRenderer.sendSync('set-key', this.key);
+    done() {
+      this.$emit('done', this.key);
     },
     cancel() {
-      this.$electron.ipcRenderer.sendSync('set-key', null);
+      this.$emit('done', null);
     },
   },
 };
 </script>
 
 <style scoped>
-::placeholder {
-  /* Most modern browsers support this now. */
-  color: darkgrey;
-}
-input[type='button'] {
-  padding: 0;
-  background: none;
-  border: none;
-}
-input[type='password'] {
-  line-height: 2em;
-}
 </style>

--- a/src/renderer/components/KeyPrompt.vue
+++ b/src/renderer/components/KeyPrompt.vue
@@ -39,10 +39,17 @@ export default {
   },
   watch: {
     enable: function() {
-      let fname = this.$store.state.Editor.crypt.op.path.split('/').pop();
+      let fname = this.$store.state.Editor.crypt.op.path;
       let opname = this.$store.state.Editor.crypt.op.name;
-      opname = opname.charAt(0).toUpperCase() + opname.slice(1);
-      this.title = opname + ' ' + fname;
+
+      if (typeof fname === 'string' && typeof opname === 'string') {
+        fname = fname.split('/').pop();
+        opname = opname.charAt(0).toUpperCase() + opname.slice(1);
+        this.title = opname + ' ' + fname;
+      } else {
+        // Unexpected situation
+        this.title = '';
+      }
     },
   },
   methods: {

--- a/src/renderer/components/KeyPrompt.vue
+++ b/src/renderer/components/KeyPrompt.vue
@@ -3,10 +3,9 @@
     <md-dialog-prompt
       :md-active.sync="enable"
       v-model="key"
-      md-title="Unlock "
+      md-title="Password is required"
       md-input-maxlength="30"
-      md-input-placeholder="Password here."
-      md-confirm-text="Done"
+      md-input-placeholder="..."
       @md-confirm="done"
       @md-cancel="cancel" />
   </div>

--- a/src/renderer/components/KeyPrompt.vue
+++ b/src/renderer/components/KeyPrompt.vue
@@ -5,6 +5,7 @@
       v-model="key"
       :md-title.sync="title"
       md-input-maxlength="30"
+      md-input-placeholder="Password is required"
       @md-confirm="done"
       @md-cancel="cancel" />
   </div>
@@ -38,9 +39,10 @@ export default {
   },
   watch: {
     enable: function() {
-      const fname = this.$store.state.Editor.crypt.op.path.split('/').pop();
-      const opname = this.$store.state.Editor.crypt.op.name;
-      this.title = 'Password is required to ' + opname + ' ' + fname;
+      let fname = this.$store.state.Editor.crypt.op.path.split('/').pop();
+      let opname = this.$store.state.Editor.crypt.op.name;
+      opname = opname.charAt(0).toUpperCase() + opname.slice(1);
+      this.title = opname + ' ' + fname;
     },
   },
   methods: {

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -4,14 +4,13 @@ import App from './App';
 import router from './router';
 import store from './store';
 
-import { MdButton, MdIcon, MdDialog, MdField, MdDialogPrompt } from 'vue-material/dist/components';
+import { MdButton, MdIcon, MdDialog, MdField } from 'vue-material/dist/components';
 Vue.use(MdButton);
 Vue.use(MdIcon);
 
 /* Required by MdDialogPrompt */
 Vue.use(MdField);
 Vue.use(MdDialog);
-Vue.use(MdDialogPrompt);
 
 import 'vue-material/dist/vue-material.min.css';
 import 'vue-material/dist/theme/default.css';

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -4,10 +4,17 @@ import App from './App';
 import router from './router';
 import store from './store';
 
-import { MdButton, MdIcon } from 'vue-material/dist/components';
+import { MdButton, MdIcon, MdDialog, MdField, MdDialogPrompt } from 'vue-material/dist/components';
 Vue.use(MdButton);
 Vue.use(MdIcon);
+
+/* Required by MdDialogPrompt */
+Vue.use(MdField);
+Vue.use(MdDialog);
+Vue.use(MdDialogPrompt);
+
 import 'vue-material/dist/vue-material.min.css';
+import 'vue-material/dist/theme/default.css';
 
 import VueCodeMirror from 'vue-codemirror';
 Vue.use(VueCodeMirror);

--- a/src/renderer/modules/Encryptor.js
+++ b/src/renderer/modules/Encryptor.js
@@ -3,58 +3,59 @@
 import crypto from 'crypto';
 import { DecryptFailError } from './Errors';
 
-function Encryptor() {
-  this.info = {
-    cipher: {
-      algorithm: 'aes-256-cbc',
-      ivLength: 16,
-    },
-    hmac: {
-      algorithm: 'sha256',
-      key: 'sjIIhOQJWjlOl4J',
-    },
-  };
-}
-
-Encryptor.prototype.getInfo = function() {
-  return this.info;
-};
-
-// return: Object { iv, enc content }
-Encryptor.prototype.encrypt = function(key, raw) {
-  let iv = crypto.randomBytes(this.info.cipher.ivLength);
-  let cipher = crypto.createCipheriv(this.info.cipher.algorithm, this.hmac(key), iv);
-  return {
-    iv: iv,
-    result: Buffer.concat([cipher.update(raw), cipher.final()]),
-  };
-};
-
-// return: Buffer
-Encryptor.prototype.decrypt = function(key, raw, iv) {
-  let decipher = crypto.createDecipheriv(this.info.cipher.algorithm, this.hmac(key), Buffer.from(iv));
-  try {
-    return Buffer.concat([decipher.update(raw), decipher.final()]);
-  } catch (err) {
-    throw new DecryptFailError('Wrong Password');
+class Encryptor {
+  constructor() {
+    this.info = {
+      cipher: {
+        algorithm: 'aes-256-cbc',
+        ivLength: 16,
+      },
+      hmac: {
+        algorithm: 'sha256',
+        key: 'sjIIhOQJWjlOl4J',
+      },
+    };
   }
-};
 
-// return: Buffer
-Encryptor.prototype.hmac = function(data) {
-  let hmac = crypto.createHmac(this.info.hmac.algorithm, this.info.hmac.key);
-  hmac.update(data);
-  return hmac.digest();
-};
+  getInfo() {
+    return this.info;
+  }
 
-// return: Array[String]
-Encryptor.prototype.listCiphers = function() {
-  return crypto.getCiphers();
-};
+  // return: Object { iv, enc content }
+  encrypt(key, content) {
+    let iv = crypto.randomBytes(this.info.cipher.ivLength);
+    let cipher = crypto.createCipheriv(this.info.cipher.algorithm, this.hmac(key), iv);
+    return {
+      iv: iv,
+      content: Buffer.concat([cipher.update(content), cipher.final()]),
+    };
+  }
 
-// return: Array[String]
-Encryptor.prototype.listHashes = function() {
-  return crypto.getHashes();
-};
+  // return: Buffer
+  decrypt(key, raw, iv) {
+    let decipher = crypto.createDecipheriv(this.info.cipher.algorithm, this.hmac(key), Buffer.from(iv));
+    try {
+      return Buffer.concat([decipher.update(raw), decipher.final()]);
+    } catch (err) {
+      throw new DecryptFailError('Wrong Password');
+    }
+  }
+
+  // return: Buffer
+  hmac(data) {
+    let hmac = crypto.createHmac(this.info.hmac.algorithm, this.info.hmac.key);
+    hmac.update(data);
+    return hmac.digest();
+  }
+
+  // return: Array[String]
+  listCiphers() {
+    return crypto.getCiphers();
+  }
+
+  listHashes() {
+    return crypto.getHashes();
+  }
+}
 
 export default new Encryptor();

--- a/src/renderer/modules/Errors.js
+++ b/src/renderer/modules/Errors.js
@@ -1,6 +1,7 @@
 const ERR_USER_CANCEL = -100;
 const ERR_ENCRYPT_FAIL = -101;
 const ERR_DECRYPT_FAIL = -102;
+const ERR_NULL_KEY = -103;
 
 /* Workaround of ReferenceError: _construct is not defined */
 const _Error = Error;
@@ -29,4 +30,21 @@ class DecryptFailError extends _Error {
   }
 }
 
-export { ERR_USER_CANCEL, UserCancelError, ERR_ENCRYPT_FAIL, EncryptFailError, ERR_DECRYPT_FAIL, DecryptFailError };
+class NullKeyError extends _Error {
+  constructor() {
+    super('Cannot find key.');
+    this.name = 'NullKeyError';
+    this.code = ERR_NULL_KEY;
+  }
+}
+
+export {
+  ERR_USER_CANCEL,
+  UserCancelError,
+  ERR_ENCRYPT_FAIL,
+  EncryptFailError,
+  ERR_DECRYPT_FAIL,
+  DecryptFailError,
+  ERR_NULL_KEY,
+  NullKeyError,
+};

--- a/src/renderer/modules/Errors.js
+++ b/src/renderer/modules/Errors.js
@@ -2,6 +2,7 @@ const ERR_USER_CANCEL = -100;
 const ERR_ENCRYPT_FAIL = -101;
 const ERR_DECRYPT_FAIL = -102;
 const ERR_NULL_KEY = -103;
+const ERR_UNEXPECTED_STATE = -104;
 
 /* Workaround of ReferenceError: _construct is not defined */
 const _Error = Error;
@@ -38,6 +39,14 @@ class NullKeyError extends _Error {
   }
 }
 
+class UnexpectedStateError extends _Error {
+  constructor(name, value) {
+    super('Unexpected state "' + name + '" with value "' + value + '"');
+    this.name = 'UnexpectedStateError';
+    this.code = ERR_UNEXPECTED_STATE;
+  }
+}
+
 export {
   ERR_USER_CANCEL,
   UserCancelError,
@@ -47,4 +56,6 @@ export {
   DecryptFailError,
   ERR_NULL_KEY,
   NullKeyError,
+  ERR_UNEXPECTED_STATE,
+  UnexpectedStateError,
 };

--- a/src/renderer/modules/Filesystem.js
+++ b/src/renderer/modules/Filesystem.js
@@ -28,12 +28,12 @@ Filesystem.prototype.shouldEncrypt = function(path) {
   return path.endsWith('.mii');
 };
 
-Filesystem.prototype.writeFile = function(path, content, cb) {
+Filesystem.prototype.writeFile = function(path, content, cb, key = null) {
   if (this.shouldEncrypt(path)) {
     // Use the cached key instead of state, because when readFile fail, I
     // can keep the old key of current file.
     // It's hard and will make code looks ugly if implemnt in Editor.vue.
-    let key = this.key;
+    key = key === null ? this.key : key;
 
     // Prevent null key, it should not happen
     // at this time.

--- a/src/renderer/modules/Filesystem.js
+++ b/src/renderer/modules/Filesystem.js
@@ -8,148 +8,143 @@ import store from '../store';
 // This file looks looks
 // | Base info | HMAC | IV | Enc Content |
 // | 16        | 32   | 16 | ..          |
-function Filesystem() {
-  this.header = {
-    length: 64,
-    baseLength: 16,
-    hmacLength: 32,
-    ivLength: 16,
-  };
-  this.key = null;
-}
 
-// Return: Object contains header metadata
-Filesystem.prototype.getHeader = function() {
-  return this.header;
-};
-
-// Return: Boolean
-Filesystem.prototype.shouldEncrypt = function(path) {
-  return path.endsWith('.mii');
-};
-
-Filesystem.prototype.writeFile = function(path, content, cb, key = null) {
-  if (this.shouldEncrypt(path)) {
-    // Use the cached key instead of state, because when readFile fail, I
-    // can keep the old key of current file.
-    // It's hard and will make code looks ugly if implemnt in Editor.vue.
-    key = key === null ? this.key : key;
-
-    // Prevent null key, it should not happen
-    // at this time.
-    if (key === '' || key === null) {
-      cb(new NullKeyError());
-      return;
-    }
-
-    // Backup file at develop.
-    if (process.env.NODE_ENV === 'development') {
-      fs.writeFile(path + '.backup.md', content, 'utf8', cb);
-    }
-
-    content = this.encrypt(key, content);
+class Filesystem {
+  constructor() {
+    this.header = {
+      length: 64,
+      baseLength: 16,
+      hmacLength: 32,
+      ivLength: 16,
+    };
+    this.key = null;
   }
 
-  fs.writeFile(path, content, 'utf8', cb);
-};
-
-Filesystem.prototype.readFile = function(path, cb) {
-  let key = null;
-  const isEncrypt = this.shouldEncrypt(path);
-
-  if (isEncrypt) {
-    key = store.state.Editor.crypt.key;
-
-    // Prevent null key, it should not happen
-    // at this time.
-    if (key === '' || key === null) {
-      cb(new NullKeyError());
-      return;
-    }
+  // Return: Object contains header metadata
+  getHeader() {
+    return this.header;
   }
 
-  // Notice it's an async function, only return
-  // the callback, not readFile
-  fs.readFile(path, (err, content) => {
-    if (err) {
-      cb(err, null);
-      return;
-    }
+  // Return: Boolean
+  shouldEncrypt(path) {
+    return path.endsWith('.mii');
+  }
 
-    // Decrypt
+  writeFile(path, content, cb, key = null) {
+    if (this.shouldEncrypt(path)) {
+      // Use the cached key instead of state, because when readFile fail, I
+      // can keep the old key of current file.
+      // It's hard and will make code looks ugly if implemnt in Editor.vue.
+      key = key === null ? this.key : key;
+      // Prevent null key, it should not happen
+      // at this time.
+      if (key === '' || key === null) {
+        cb(new NullKeyError());
+        return;
+      }
+      // Backup file at develop.
+      if (process.env.NODE_ENV === 'development') {
+        fs.writeFile(path + '.backup.md', content, 'utf8', cb);
+      }
+      content = this.encrypt(key, content);
+    }
+    fs.writeFile(path, content, 'utf8', cb);
+  }
+
+  readFile(path, cb) {
+    let key = null;
+    const isEncrypt = this.shouldEncrypt(path);
+
     if (isEncrypt) {
-      try {
-        content = this.decrypt(key, content);
-      } catch (err2) {
-        cb(err2, null);
+      key = store.state.Editor.crypt.key;
+      // Prevent null key, it should not happen
+      // at this time.
+      if (key === '' || key === null) {
+        cb(new NullKeyError());
         return;
       }
     }
-
-    this.updateKey(key);
-    cb(null, content.toString('utf8'));
-  });
-};
-
-Filesystem.prototype.encrypt = function(key, content) {
-  // This return { iv, result }
-  let encResult = encryptor.encrypt(key, content);
-  let bufHmac = encryptor.hmac(content);
-  // Pack base info, hmac of origin content, iv, enc content
-  let bufFile = this.packHeader(encResult, bufHmac);
-  return bufFile;
-};
-
-Filesystem.prototype.decrypt = function(key, content) {
-  let fileStruct = this.unpackHeader(content);
-  try {
-    let decContent = encryptor.decrypt(key, fileStruct.encContent, fileStruct.iv);
-    if (encryptor.hmac(decContent).equals(fileStruct.hmac)) {
-      return decContent;
-    } else {
-      throw new DecryptFailError('Content mismatch.');
-    }
-  } catch (err) {
-    throw err;
+    // Notice it's an async function, only return
+    // the callback, not readFile
+    fs.readFile(path, (err, content) => {
+      if (err) {
+        cb(err, null);
+        return;
+      }
+      // Decrypt
+      if (isEncrypt) {
+        try {
+          content = this.decrypt(key, content);
+        } catch (err2) {
+          cb(err2, null);
+          return;
+        }
+      }
+      this.updateKey(key);
+      cb(null, content.toString('utf8'));
+    });
   }
-};
 
-// Return: Buffer
-Filesystem.prototype.packHeader = function(encResult, bufHmac) {
-  const info = this.getHeader();
-  let bufHeader = Buffer.alloc(info.length);
-  // * Base info, add whatever you want :P
-  bufHeader.write('Miikun@2018');
-  // * Encrypt info
-  bufHmac.copy(bufHeader, info.baseLength);
-  // * IV
-  encResult.iv.copy(bufHeader, info.baseLength + info.hmacLength);
-  // this.dumpHeader(bufHeader)
-  return Buffer.concat([bufHeader, encResult.result]);
-};
+  encrypt(key, content) {
+    // This return { iv, content }
+    let encResult = encryptor.encrypt(key, content);
+    let bufHmac = encryptor.hmac(content);
+    // Pack base info, hmac of origin content, iv, enc content
+    let bufFile = this.packHeader(encResult, bufHmac);
+    return bufFile;
+  }
 
-Filesystem.prototype.unpackHeader = function(raw) {
-  const info = this.getHeader();
-  let base = raw.slice(0, info.baseLength);
-  let hmac = raw.slice(info.baseLength, info.baseLength + info.hmacLength);
-  let iv = raw.slice(info.baseLength + info.hmacLength, info.length);
-  let encContent = raw.slice(info.length);
-  return { base, hmac, iv, encContent };
-};
+  decrypt(key, content) {
+    let fileStruct = this.unpackHeader(content);
+    try {
+      let decContent = encryptor.decrypt(key, fileStruct.encContent, fileStruct.iv);
+      if (encryptor.hmac(decContent).equals(fileStruct.hmac)) {
+        return decContent;
+      } else {
+        throw new DecryptFailError('Content mismatch.');
+      }
+    } catch (err) {
+      throw err;
+    }
+  }
 
-Filesystem.prototype.dumpHeader = function(header) {
-  const info = this.getHeader();
-  let base = header.slice(0, info.baseLength);
-  let hmac = header.slice(info.baseLength, info.baseLength + info.hmacLength);
-  let iv = header.slice(info.baseLength + info.hmacLength, info.length);
-  console.log('[Dump Header] Total bytes: ' + header.byteLength);
-  console.log('[Dump Header] Base info: ' + base.toString('utf8'));
-  console.log('[Dump Header] HMAC: ' + hmac.toString('utf8'));
-  console.log('[Dump Header] IV: ' + iv.toString('utf8'));
-};
+  // Return: Buffer
+  packHeader(encResult, bufHmac) {
+    const info = this.getHeader();
+    let bufHeader = Buffer.alloc(info.length);
+    // * Base info, add whatever you want :P
+    bufHeader.write('Miikun@2018');
+    // * Encrypt info
+    bufHmac.copy(bufHeader, info.baseLength);
+    // * IV
+    encResult.iv.copy(bufHeader, info.baseLength + info.hmacLength);
+    // this.dumpHeader(bufHeader)
+    return Buffer.concat([bufHeader, encResult.content]);
+  }
 
-Filesystem.prototype.updateKey = function(key) {
-  this.key = key;
-};
+  unpackHeader(raw) {
+    const info = this.getHeader();
+    let base = raw.slice(0, info.baseLength);
+    let hmac = raw.slice(info.baseLength, info.baseLength + info.hmacLength);
+    let iv = raw.slice(info.baseLength + info.hmacLength, info.length);
+    let encContent = raw.slice(info.length);
+    return { base, hmac, iv, encContent };
+  }
+
+  dumpHeader(header) {
+    const info = this.getHeader();
+    let base = header.slice(0, info.baseLength);
+    let hmac = header.slice(info.baseLength, info.baseLength + info.hmacLength);
+    let iv = header.slice(info.baseLength + info.hmacLength, info.length);
+    console.log('[Dump Header] Total bytes: ' + header.byteLength);
+    console.log('[Dump Header] Base info: ' + base.toString('utf8'));
+    console.log('[Dump Header] HMAC: ' + hmac.toString('utf8'));
+    console.log('[Dump Header] IV: ' + iv.toString('utf8'));
+  }
+
+  updateKey(key) {
+    this.key = key;
+  }
+}
 
 export default new Filesystem();

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import Router from 'vue-router';
 import Main from '@/components/Main.vue';
-import EncryptKeyPrompt from '@/components/EncryptKeyPrompt.vue';
+import EncryptKeyPrompt from '@/components/KeyPrompt.vue';
 
 Vue.use(Router);
 
@@ -13,8 +13,8 @@ export default new Router({
       component: Main,
     },
     {
-      path: '/ask-encrypt-key',
-      name: 'mii-encrypt-key-prompt',
+      path: '/ask-key',
+      name: 'mii-key-prompt',
       component: EncryptKeyPrompt,
     },
     {

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import Router from 'vue-router';
 import Main from '@/components/Main.vue';
-import EncryptKeyPrompt from '@/components/KeyPrompt.vue';
 
 Vue.use(Router);
 
@@ -11,11 +10,6 @@ export default new Router({
       path: '/',
       name: 'mii-main',
       component: Main,
-    },
-    {
-      path: '/ask-key',
-      name: 'mii-key-prompt',
-      component: EncryptKeyPrompt,
     },
     {
       path: '*',

--- a/src/renderer/store/modules/Editor.js
+++ b/src/renderer/store/modules/Editor.js
@@ -9,7 +9,7 @@ const state = {
     key: null,
     op: {
       name: null,
-      newFilePath: null,
+      path: null,
     },
   },
 };
@@ -41,7 +41,7 @@ const mutations = {
   },
   SET_CRYPT_OP(state, obj) {
     state.crypt.op.name = obj.name;
-    state.crypt.op.newFilePath = obj.newFilePath;
+    state.crypt.op.path = obj.path;
   },
 };
 

--- a/src/renderer/store/modules/Editor.js
+++ b/src/renderer/store/modules/Editor.js
@@ -4,6 +4,14 @@ const state = {
   openToolbar: true,
   canUndo: false,
   canRedo: false,
+  crypt: {
+    enable: false,
+    key: null,
+    op: {
+      name: null,
+      newFilePath: null,
+    },
+  },
 };
 
 const mutations = {
@@ -25,6 +33,16 @@ const mutations = {
   SET_CAN_REDO(state, bool) {
     state.canRedo = bool;
   },
+  SET_CRYPT_ENABLE(state, bool) {
+    state.crypt.enable = bool;
+  },
+  SET_CRYPT_KEY(state, key) {
+    state.crypt.key = key;
+  },
+  SET_CRYPT_OP(state, obj) {
+    state.crypt.op.name = obj.name;
+    state.crypt.op.newFilePath = obj.newFilePath;
+  },
 };
 
 const actions = {
@@ -42,6 +60,15 @@ const actions = {
   },
   setCanRedo({ commit }, bool) {
     commit('SET_CAN_REDO', bool);
+  },
+  setCryptEnable({ commit }, bool) {
+    commit('SET_CRYPT_ENABLE', bool);
+  },
+  setCryptKey({ commit }, key) {
+    commit('SET_CRYPT_KEY', key);
+  },
+  setCryptOP({ commit }, obj) {
+    commit('SET_CRYPT_OP', obj);
   },
 };
 


### PR DESCRIPTION
Sorry, this is a little large scale change. Because there is vuex and vue-material, therefore

1. Rewrite KeyPrompt as component of editor
- Remove ipc
- Remove related route
- Add crypt state

2. Use vue-material component in KeyPrompt.
3. Improve filesystem, not to ask password when saving an opened file.

Any question or advice is welcome.