### PR TITLE
Decouple drop field file opening

### DIFF
--- a/src/components/DropField.vue
+++ b/src/components/DropField.vue
@@ -27,6 +27,7 @@ export default {
     },
     dropFile(file, ext) {
       if (this.isAllowExt(file.type, ext)) {
+        // Editor determines encryption from the emitted path.
         this.$emit('open-file-path', file.path);
       } else {
         getSelectedResult({

--- a/src/components/DropField.vue
+++ b/src/components/DropField.vue
@@ -27,12 +27,7 @@ export default {
     },
     dropFile(file, ext) {
       if (this.isAllowExt(file.type, ext)) {
-        this.$parent.saveModifyFile();
-        if (ext === 'mii') {
-          this.$parent.openKeyPrompt('open', file.path);
-        } else {
-          this.$parent.readFile(file.path);
-        }
+        this.$emit('open-file', file.path);
       } else {
         getSelectedResult({
           title: 'error',

--- a/src/components/DropField.vue
+++ b/src/components/DropField.vue
@@ -27,7 +27,7 @@ export default {
     },
     dropFile(file, ext) {
       if (this.isAllowExt(file.type, ext)) {
-        this.$emit('open-file', file.path);
+        this.$emit('open-file-path', file.path);
       } else {
         getSelectedResult({
           title: 'error',

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -4,7 +4,7 @@
       <textarea ref="editor" v-model="code" />
     </div>
     <div v-if="isPreview == true" class="preview"><div class="markdown-body" v-html="htmlCode" /></div>
-    <DropField />
+    <DropField @open-file="openFilePath" />
     <KeyPrompt @done="onKeyPromptDone" />
   </div>
 </template>
@@ -154,15 +154,16 @@ export default {
       const files = showFileOpenDialog();
 
       if (files) {
-        const path = files[0];
-
-        // 編集済み：合保存するか確認ダイアログを表示する
-        this.saveModifyFile();
-        if (fs.shouldEncrypt(path)) {
-          this.openKeyPrompt('open', path);
-        } else {
-          this.readFile(path);
-        }
+        this.openFilePath(files[0]);
+      }
+    },
+    openFilePath(path) {
+      // 編集済み：合保存するか確認ダイアログを表示する
+      this.saveModifyFile();
+      if (fs.shouldEncrypt(path)) {
+        this.openKeyPrompt('open', path);
+      } else {
+        this.readFile(path);
       }
     },
     readFile(path) {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -4,7 +4,7 @@
       <textarea ref="editor" v-model="code" />
     </div>
     <div v-if="isPreview == true" class="preview"><div class="markdown-body" v-html="htmlCode" /></div>
-    <DropField @open-file="openFilePath" />
+    <DropField @open-file-path="openFilePath" />
     <KeyPrompt @done="onKeyPromptDone" />
   </div>
 </template>
@@ -158,7 +158,9 @@ export default {
       }
     },
     openFilePath(path) {
-      // 編集済み：合保存するか確認ダイアログを表示する
+      if (typeof path !== 'string' || path === '') return;
+
+      // 編集済み：保存するか確認ダイアログを表示する
       this.saveModifyFile();
       if (fs.shouldEncrypt(path)) {
         this.openKeyPrompt('open', path);


### PR DESCRIPTION
## Summary

- Route dropped files through an open-file event instead of calling parent methods from DropField.
- Add an openFilePath handler in Editor so file picker and drop handling share the same file-open flow.
- Keep the existing save prompt, encrypted file prompt, and read behavior unchanged.

## Why

DropField previously knew about several Editor implementation methods through , which made the file-open flow harder to change safely. This keeps the seam small: DropField reports the path to open, while Editor owns the document-opening behavior.

## Validation

- npm run build passed. Existing Sass deprecation warnings remain.
- Vue SFC parse/template compile passed for src/components/Editor.vue and src/components/DropField.vue.
- npx prettier --check src/components/Editor.vue src/components/DropField.vue passed.
- git diff --check passed.

## Notes

npm run lint still fails because the existing Vue CLI ESLint integration passes removed options to ESLint 10. npm run lint:scss still fails due existing stylelint configuration/rule compatibility issues and because the script targets all of src, including non-style files.