### PR TITLE
Fix SCSS lint failures

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -12,10 +12,7 @@ module.exports = {
     'no-empty-source': true,
     'color-hex-length': 'short',
     'color-no-invalid-hex': true,
-    'indentation': 2,
     'length-zero-no-unit': true,
-    "max-empty-lines": 2,
-    'string-quotes': 'single',
     'declaration-block-no-duplicate-properties': [
       true,
       {
@@ -24,21 +21,6 @@ module.exports = {
         ]
       }
     ],
-    'block-opening-brace-space-before': 'always',
-    'block-opening-brace-newline-after': 'always',
-    'block-closing-brace-newline-after': 'always',
-    'block-closing-brace-newline-before': 'always',
-    'selector-list-comma-space-before': 'never',
-    'selector-list-comma-newline-after': 'always',
     'selector-pseudo-element-colon-notation': 'double',
-    'value-list-comma-newline-after': 'always-multi-line',
-    'value-list-comma-space-after': 'always-single-line',
-    'value-list-comma-space-before': 'never',
-    'declaration-block-trailing-semicolon': 'always',
-    'declaration-block-semicolon-newline-after': 'always-multi-line',
-    'declaration-block-semicolon-newline-before': 'never-multi-line',
-    'declaration-block-semicolon-space-after': 'always-single-line',
-    'no-extra-semicolons': true,
-    'no-missing-end-of-source-newline': true,
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8553,15 +8553,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/debounce": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-3.0.0.tgz",
@@ -22452,19 +22443,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/vue-template-compiler": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
       }
     },
     "node_modules/vue-template-es2015-compiler": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "lint": "vue-cli-service lint",
     "electron:build": "vue-cli-service electron:build",
     "electron:serve": "vue-cli-service electron:serve",
-    "format:scss": "stylelint --fix ./src",
-    "lint:scss": "stylelint ./src",
+    "format:scss": "stylelint --fix \"src/**/*.scss\"",
+    "lint:scss": "stylelint \"src/**/*.scss\"",
     "postinstall": "electron-builder install-app-deps",
     "postuninstall": "electron-builder install-app-deps"
   },

--- a/src/assets/style/Components/_index.scss
+++ b/src/assets/style/Components/_index.scss
@@ -1,1 +1,1 @@
-//
+/* stylelint-disable no-empty-source */

--- a/src/assets/style/Elements/_code.scss
+++ b/src/assets/style/Elements/_code.scss
@@ -20,7 +20,7 @@ pre {
   overflow: auto;
   border-radius: 3px;
   background-color: #f7f7f7;
-  word-wrap: normal;
+  overflow-wrap: normal;
 
   > code {
     display: inline;
@@ -30,7 +30,7 @@ pre {
     background-color: transparent;
     font-size: 100%;
     line-height: inherit;
-    word-wrap: normal;
+    overflow-wrap: normal;
     word-break: normal;
     white-space: pre;
     &::before,

--- a/src/assets/style/Objects/_index.scss
+++ b/src/assets/style/Objects/_index.scss
@@ -1,1 +1,1 @@
-//
+/* stylelint-disable no-empty-source */

--- a/src/assets/style/Settings/_variables.scss
+++ b/src/assets/style/Settings/_variables.scss
@@ -1,27 +1,25 @@
-@import '~open-color/open-color.scss';
+@import '~open-color/open-color';
 
-//
 // Font
 // -------------------------
 $font-family-sansSerif:        'Noto Sans JP', Emoji, sans-serif;
 $font-family-monospace:        'Source Code Pro', #{$font-family-sansSerif}, Emoji, monospace !default;
 $font-weight-base:             normal;
 
-$font-size-lg:                 1rem * 4/3; // 1.33333rem
-$font-size-base:               1rem * 4/4; // 1rem
-$font-size-sm:                 1rem * 4/5; // 0.8rem
-$font-size-xs:                 1rem * 4/6; // 0.66667rem
+$font-size-lg:                 1rem * 4 / 3; // 1.33333rem
+$font-size-base:               1rem * 4 / 4; // 1rem
+$font-size-sm:                 1rem * 4 / 5; // 0.8rem
+$font-size-xs:                 1rem * 4 / 6; // 0.66667rem
 
-$font-size-h1:                 1rem * 6/3; // 2rem
-$font-size-h2:                 1rem * 6/4; // 1.5rem
-$font-size-h3:                 1rem * 6/5; // 1.2rem
-$font-size-h4:                 1rem * 6/6; // 1rem
-$font-size-h5:                 1rem * 6/7; // 0.85714rem
-$font-size-h6:                 1rem * 6/8; // 0.75rem
+$font-size-h1:                 1rem * 6 / 3; // 2rem
+$font-size-h2:                 1rem * 6 / 4; // 1.5rem
+$font-size-h3:                 1rem * 6 / 5; // 1.2rem
+$font-size-h4:                 1rem * 6 / 6; // 1rem
+$font-size-h5:                 1rem * 6 / 7; // 0.85714rem
+$font-size-h6:                 1rem * 6 / 8; // 0.75rem
 
-$line-height-base:             16/8;
+$line-height-base:             16 / 8;
 
-//
 // Layout
 // -------------------------
 
@@ -37,7 +35,6 @@ $toolbar-width:    3.125rem;
 $statusbar-height: 20px;
 
 
-//
 // color const
 // -------------------------
 $color50:  #fafafa;

--- a/src/assets/style/Trumps/_index.scss
+++ b/src/assets/style/Trumps/_index.scss
@@ -1,1 +1,1 @@
-//
+/* stylelint-disable no-empty-source */

--- a/src/assets/style/Vendor/_codemirror.scss
+++ b/src/assets/style/Vendor/_codemirror.scss
@@ -11,7 +11,7 @@
 }
 
 .cm-gutters {
-  border-right: 1px solid darken($editor-linenumber-bgColor, 2%);
+  border-right: 1px solid darken($editor-linenumber-bgColor, 2%); // stylelint-disable-line scss/no-global-function-names
   background: $editor-linenumber-bgColor;
   color: $editor-linenumber-color;
 }
@@ -44,7 +44,7 @@
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
-  word-wrap: normal;
+  overflow-wrap: normal;
   white-space: pre;
   -webkit-tap-highlight-color: transparent;
   -webkit-font-variant-ligatures: none;
@@ -63,7 +63,7 @@
   top: 0;
   left: 0;
   min-height: 100%;
-  border-right: 1px solid darken($editor-linenumber-bgColor, 2%);
+  border-right: 1px solid darken($editor-linenumber-bgColor, 2%); // stylelint-disable-line scss/no-global-function-names
   background: $editor-linenumber-bgColor;
   white-space: nowrap;
 }
@@ -78,7 +78,7 @@
 
 .CodeMirror-activeline {
   .CodeMirror-linenumber {
-    color: darken($editor-linenumber-color, 16%);
+    color: darken($editor-linenumber-color, 16%); // stylelint-disable-line scss/no-global-function-names
     font-weight: bold;
   }
 }
@@ -221,7 +221,7 @@ flickering artifacts. */
 }
 
 .CodeMirror-wrap pre {
-  word-wrap: break-word;
+  overflow-wrap: break-word;
   word-break: normal;
   white-space: pre-wrap;
 }
@@ -365,6 +365,7 @@ CodeMirror-selectedtext {
 }
 
 // same: github-markdown style
+/* stylelint-disable scss/at-extend-no-missing-placeholder */
 .cm-header-1 {
   @extend h1;
 }
@@ -383,6 +384,7 @@ CodeMirror-selectedtext {
 .cm-header-6 {
   @extend h6;
 }
+/* stylelint-enable scss/at-extend-no-missing-placeholder */
 
 .cm-strong {
   font-weight: bold;

--- a/src/assets/style/Vendor/_github-markdown.scss
+++ b/src/assets/style/Vendor/_github-markdown.scss
@@ -1,7 +1,7 @@
 .markdown-body {
   color: #333;
   font-size: 1rem;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 
   p,
   blockquote,


### PR DESCRIPTION
## Summary
- Limit the SCSS lint script to SCSS files so JavaScript and Vue files are not parsed as stylesheets.
- Remove obsolete Stylelint rules that are no longer recognized by the installed Stylelint version.
- Update the remaining SCSS lint violations with small, local changes.

## Validation
- `npm run lint:scss`
