### PR TITLE
Refactor editor boundary services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Vue CLI 5 + vue-cli-plugin-electron-builder (webpack). Two entry points:
 Each third-party library is imported by exactly one adapter module; the rest of the app depends on the adapter's app-facing API. Dependency direction: `components → services → adapters → libraries`. `shared/` and `store/` may be used from any layer, **except adapters must never import the store** — callers pass state in. The boundaries are machine-enforced via `no-restricted-imports` in `.eslintrc.js` (per-directory `overrides`).
 
 - `src/adapters/` — one file per external dependency surface: `editor.js` (CodeMirror 6), `markdown.js` (markdown-it + shiki), `filesystem.js` (Node `fs`), `encryptor.js` (Node `crypto`), `electron.js` (`electron` + `@electron/remote`: dialogs, menu build/checkbox state, shell, window, nativeTheme, webUtils)
-- `src/services/` — application logic: `app-menu.js` (menu template + setup + checkbox sync), `app-menu-controller.js` (EventBus/store dispatch only), `link-title.js` (paste-URL title fetch)
+- `src/services/` — application logic: `active-document.js` (content/path/clean-history state transitions), `file-operation.js` (open/save orchestration), `render-pipeline.js` (async preview render sequencing), `editor-commands.js` (EventBus command binding), `app-menu.js` (menu template + setup + checkbox sync), `app-menu-controller.js` (EventBus/store dispatch only), `link-title.js` (paste-URL title fetch)
 - `src/shared/` — pure utilities with no internal deps: `event-bus.js`, `errors.js`, `url.js`
 - `src/store/` — the single Vuex store (`index.js`) + auto-registered `modules/`
 
@@ -45,19 +45,19 @@ Swapping a library means rewriting one adapter file while keeping its exported A
 
 ### Command flow: native menu → EventBus → Editor.vue
 
-File operations are triggered from the native app menu, not from Vue components:
+File operations and native menu Undo/Redo are triggered from the native app menu, not from Vue components:
 
-`src/services/app-menu.js` (menu template + accelerators) → `src/services/app-menu-controller.js` → `EventBus.$emit(...)` (`src/shared/event-bus.js`, EventTarget-based) → listeners in `src/components/Editor.vue` (`newFile` / `openFile` / `saveFile` / `saveAs` / `undo` / `redo`) → `src/adapters/filesystem.js` + synchronous dialogs from `src/adapters/electron.js`.
+`src/services/app-menu.js` (menu template + accelerators) → `src/services/app-menu-controller.js` → `EventBus.$emit(...)` (`src/shared/event-bus.js`, EventTarget-based) → `src/services/editor-commands.js` bindings → handlers in `src/components/Editor.vue` (`newFile` / `openFile` / `saveFile` / `saveAs` / `undo` / `redo`).
 
 UI state (preview/toolbar toggles, always-on-top, undo/redo availability) flows through Vuex instead of the EventBus; menu checkbox state follows the store via `store.subscribe` in `services/app-menu.js` — controllers never reach back into the menu.
 
 ### Editor: CodeMirror 6 behind a CM5-style compat layer
 
-`src/adapters/editor.js` wraps CodeMirror 6 but exposes the old CodeMirror 5 API shape through `createCompatApi()`. Components interact via `this.editor.cm` (`on('change')`, `getValue()`, `replaceRange(text, {line, ch})`, `historySize()`, ...). Extend the compat object rather than handing the CM6 `EditorView` to components. The adapter is store-free: `Editor.vue` reads `historySize()` in its `changes` handler to dispatch `setCanUndo`/`setCanRedo`, and dispatches `initFilePath` itself. Custom keymap: Mod-b (bold), Mod-i (italic), Shift-@ (inline code). Dirty tracking compares against `cleanValue` (`isClean`/`markClean`); `clearHistory()` recreates the entire EditorView.
+`src/adapters/editor.js` wraps CodeMirror 6 but exposes the old CodeMirror 5 API shape through `createCompatApi()`. Components interact via `this.editor.cm` (`on('change')`, `getValue()`, `replaceRange(text, {line, ch})`, `historySize()`, ...). Extend the compat object rather than handing the CM6 `EditorView` to components. The adapter is store-free: `Editor.vue` reads `historySize()` in its `changes` handler to dispatch `setCanUndo`/`setCanRedo`; `src/services/active-document.js` handles file path and clean-history transitions after open/save/new document actions. Custom keymap: Mod-b (bold), Mod-i (italic), Shift-@ (inline code). Dirty tracking compares against `cleanValue` (`isClean`/`markClean`); `clearHistory()` recreates the entire EditorView.
 
 ### Encrypted .mii files
 
-A `.mii` extension switches the `Filesystem` singleton (`src/adapters/filesystem.js`) into encrypt mode: binary layout `| base info 16B | HMAC 32B | IV 16B | ciphertext |`, AES-256-CBC with the key derived via HMAC-SHA256 (`src/adapters/encryptor.js`). `readFile(path, cb, key)` and `writeFile(path, content, cb, key)` take the key from the caller — because the password prompt (`KeyPrompt.vue`) is async, the pending operation is stored in Vuex as `Editor.crypt.op = { name: 'open'|'save', path }` and resumed in `Editor.vue#onKeyPromptDone`, which passes the entered key down. The last successful key is cached on the Filesystem instance so plain saves don't re-prompt.
+A `.mii` extension switches the `Filesystem` singleton (`src/adapters/filesystem.js`) into encrypt mode: binary layout `| base info 16B | HMAC 32B | IV 16B | ciphertext |`, AES-256-CBC with the key derived via HMAC-SHA256 (`src/adapters/encryptor.js`). `readFile(path, cb, key)` and `writeFile(path, content, cb, key)` take the key from the caller — because the password prompt (`KeyPrompt.vue`) is async, the pending operation is stored in Vuex as `Editor.crypt.op = { name: 'open'|'save', path }` and resumed in `Editor.vue#onKeyPromptDone`, which passes the entered key to `src/services/file-operation.js`. The last successful key is cached on the Filesystem instance so existing encrypted saves can reuse it; if an existing encrypted save has no cached key, `Editor.vue` reopens the key prompt before writing.
 
 ### State: single Vuex store
 
@@ -65,7 +65,11 @@ A `.mii` extension switches the `Filesystem` singleton (`src/adapters/filesystem
 
 ### Markdown preview
 
-`src/adapters/markdown.js`: markdown-it (+ checkbox, footnote, anchor, multimd-table, deflist plugins) with shiki highlighting (github-light/github-dark dual themes switched by `prefers-color-scheme`; block background pinned to `--code-bg` in `Vendor/_shiki.scss`). `render()` is async: it scans fenced code blocks and `loadLanguage`s any missing grammars before the synchronous markdown-it pass, so the first paint is already highlighted. `Editor.vue` renders the output with `v-html` via a sequence-guarded `renderPreview` (debounced 200ms), only while the preview pane is open.
+`src/adapters/markdown.js`: markdown-it (+ checkbox, footnote, anchor, multimd-table, deflist plugins) with shiki highlighting (github-light/github-dark dual themes switched by `prefers-color-scheme`; block background pinned to `--code-bg` in `Vendor/_shiki.scss`). `render()` is async: it scans fenced code blocks and `loadLanguage`s any missing grammars before the synchronous markdown-it pass, so the first paint is already highlighted. `src/services/render-pipeline.js` owns the sequence guard that drops stale async render results; `Editor.vue` requests rendering and publishes the resulting preview HTML with `v-html` only while the preview pane is open.
+
+### Editor boundary map
+
+For editor/file/preview/command ownership, start with `docs/architecture/editor-boundaries.md`.
 
 ### Styling
 

--- a/src/adapters/filesystem.js
+++ b/src/adapters/filesystem.js
@@ -28,6 +28,10 @@ class Filesystem {
     return path.endsWith('.mii');
   }
 
+  hasKey() {
+    return this.key !== '' && this.key !== null;
+  }
+
   writeFile(path, content, cb, key = null) {
     if (this.shouldEncrypt(path)) {
       // Use the cached key instead of state, because when readFile fail, I

--- a/src/components/DropField.vue
+++ b/src/components/DropField.vue
@@ -21,7 +21,7 @@ export default {
           e.preventDefault();
           const file = e.dataTransfer.files[0];
           if (!file) return;
-          const ext = file.name.split('.')[1];
+          const ext = this.getFileExtension(file.name);
           this.dropFile(file, ext);
         },
         true,
@@ -71,6 +71,12 @@ export default {
     },
     isAllowExt(type, ext) {
       return type === 'text/plain' || type === 'application/text' || ext === 'txt' || ext === 'md' || ext === 'mii';
+    },
+    getFileExtension(name) {
+      const parts = name.split('.');
+      if (parts.length < 2) return '';
+
+      return parts.pop().toLowerCase();
     },
   },
 };

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -13,20 +13,22 @@
 import { mapState } from 'vuex';
 import debounce from 'debounce';
 import fs from '@/adapters/filesystem.js';
-import Markdown from '@/adapters/markdown.js';
-import {
-  openDialog,
-  showFileOpenDialog,
-  getSavePath,
-  getSelectedResult,
-  openLinkExternal,
-} from '@/adapters/electron.js';
+import { openDialog, showFileOpenDialog, getSelectedResult, openLinkExternal } from '@/adapters/electron.js';
 import Editor from '@/adapters/editor.js';
 import DropField from '@/components/DropField';
 import KeyPrompt from '@/components/KeyPrompt';
 import { UnexpectedStateError } from '@/shared/errors';
-import { EventBus } from '@/shared/event-bus';
+import { clearActiveDocument, markActiveDocumentSaved, replaceActiveDocument } from '@/services/active-document';
+import { registerEditorCommands } from '@/services/editor-commands';
+import {
+  openEncryptedFile as openEncryptedFileOperation,
+  openPlainFile as openPlainFileOperation,
+  saveEncryptedFile,
+  savePlainFile,
+  selectDocumentSavePath,
+} from '@/services/file-operation';
 import { getLinkWithTitle } from '@/services/link-title';
+import RenderPipeline from '@/services/render-pipeline';
 
 export default {
   name: 'MiiEditor',
@@ -37,9 +39,8 @@ export default {
   data() {
     return {
       editor: null,
-      markdown: null,
+      renderPipeline: new RenderPipeline(),
       htmlCode: '',
-      renderSeq: 0,
       saveTimer: -1,
     };
   },
@@ -68,8 +69,6 @@ export default {
     },
   },
   mounted() {
-    this.markdown = new Markdown();
-
     this.$nextTick(() => {
       this.initialize();
     });
@@ -106,32 +105,31 @@ export default {
       openLinkExternal();
     },
     onEditorReady() {
-      EventBus.$on('undo', () => {
-        this.editor.cm.undo();
-      });
-      EventBus.$on('redo', () => {
-        this.editor.cm.redo();
-      });
-      EventBus.$on('newFile', () => {
-        this.newFile();
-      });
-      EventBus.$on('openFile', () => {
-        this.openFile();
-      });
-      EventBus.$on('saveFile', () => {
-        this.saveFile();
-      });
-      EventBus.$on('saveAs', () => {
-        this.saveAs();
+      registerEditorCommands({
+        undo: () => {
+          this.editor.cm.undo();
+        },
+        redo: () => {
+          this.editor.cm.redo();
+        },
+        newFile: () => {
+          this.newFile();
+        },
+        openFile: () => {
+          this.openFile();
+        },
+        saveFile: () => {
+          this.saveFile();
+        },
+        saveAs: () => {
+          this.saveAs();
+        },
       });
     },
     async renderPreview(code) {
-      // Grammar loading makes render async; drop stale results that finish late.
-      const seq = ++this.renderSeq;
-      const html = await this.markdown.render(code);
-      if (seq === this.renderSeq) {
+      await this.renderPipeline.requestRender(code, (html) => {
         this.htmlCode = html;
-      }
+      });
     },
     onEditorCodeChange: debounce(function (newCode) {
       this.$store.dispatch('updateCode', newCode);
@@ -165,10 +163,12 @@ export default {
       const canContinue = await this.saveModifyFile();
       if (!canContinue) return;
 
-      this.renderSeq++;
+      this.renderPipeline.discardPendingResults();
       this.htmlCode = '';
-      this.editor.clean();
-      this.$store.dispatch('initFilePath', '');
+      clearActiveDocument({
+        editor: this.editor,
+        store: this.$store,
+      });
     },
     async openFile() {
       const files = showFileOpenDialog();
@@ -186,72 +186,60 @@ export default {
 
       if (fs.shouldEncrypt(path)) {
         this.openKeyPrompt('open', path);
+        return false;
       } else {
-        this.readFile(path);
+        return this.openPlainFile(path);
       }
-
-      return true;
     },
-    readFile(path, key = null) {
-      if (this.path === path) {
-        getSelectedResult({
-          title: '',
-          type: 'warning',
-          buttons: ['Yes'],
-          message: path,
-          detail: 'This file is already open.',
-        });
-        return;
-      }
-
-      fs.readFile(
+    openPlainFile(path) {
+      return openPlainFileOperation({
         path,
-        (err, content) => {
-          if (err === null) {
-            this.editor.setValue(content);
-            this.$store.dispatch('initFilePath', path);
-            this.editor.clearHistory();
-          } else {
-            openDialog('error', err.toString());
-          }
+        currentPath: this.path,
+        onOpened: (content) => {
+          this.applyOpenedFile(path, content);
         },
-        key,
-      );
+      });
     },
-    saveAsDialog() {
-      const savePath = getSavePath([
-        { name: 'Markdown file', extensions: ['md'] },
-        { name: 'Text file', extensions: ['txt'] },
-        { name: 'Mii file', extensions: ['mii'] },
-      ]);
-
-      return savePath;
+    openEncryptedFile(path, key) {
+      return openEncryptedFileOperation({
+        path,
+        currentPath: this.path,
+        key,
+        onOpened: (content) => {
+          this.applyOpenedFile(path, content);
+        },
+      });
+    },
+    applyOpenedFile(path, content) {
+      replaceActiveDocument({
+        editor: this.editor,
+        store: this.$store,
+        path,
+        content,
+      });
     },
     async saveFile() {
       const isNewFile = !this.path;
       let savePath = this.path;
 
       if (!savePath) {
-        savePath = this.saveAsDialog();
+        savePath = selectDocumentSavePath();
         if (!savePath) return false;
       }
 
-      if (fs.shouldEncrypt(savePath) && isNewFile) {
+      if (fs.shouldEncrypt(savePath) && (isNewFile || !fs.hasKey())) {
         this.openKeyPrompt('save', savePath);
         return false;
       }
 
-      const result = await this.writeFile(savePath);
-
-      if (result) {
-        this.$store.dispatch('initFilePath', savePath);
-        this.editor.clearHistory();
+      if (!fs.shouldEncrypt(savePath)) {
+        return this.savePlainFile(savePath);
       }
 
-      return result;
+      return this.saveEncryptedFile(savePath);
     },
     async saveAs() {
-      const savePath = this.saveAsDialog();
+      const savePath = selectDocumentSavePath();
 
       if (!savePath) return false;
 
@@ -260,72 +248,71 @@ export default {
         return false;
       }
 
-      const result = await this.writeFile(savePath);
+      return this.savePlainFile(savePath);
+    },
+    async savePlainFile(path) {
+      const result = await savePlainFile({
+        path,
+        content: this.editor.cm.getValue(),
+      });
 
       if (result) {
-        this.$store.dispatch('initFilePath', savePath);
-        this.editor.clearHistory();
+        this.applySavedFile(path);
       }
 
       return result;
     },
-    writeFile(path = this.path, key = null) {
-      return new Promise((resolve) => {
-        try {
-          fs.writeFile(
-            path,
-            this.editor.cm.getValue(),
-            (err) => {
-              if (err) {
-                openDialog('error', err.toString());
-                resolve(false);
-                return;
-              }
-
-              if (key !== null) {
-                fs.updateKey(key);
-              }
-
-              resolve(true);
-            },
-            key,
-          );
-        } catch (e) {
-          openDialog('error', e.toString());
-          resolve(false);
-        }
+    applySavedFile(path) {
+      markActiveDocumentSaved({
+        editor: this.editor,
+        store: this.$store,
+        path,
       });
     },
+    async saveEncryptedFile(path, key = null) {
+      const result = await saveEncryptedFile({
+        path,
+        content: this.editor.cm.getValue(),
+        key,
+      });
+
+      if (result) {
+        this.applySavedFile(path);
+      }
+
+      return result;
+    },
     openKeyPrompt(name = null, path = null) {
-      this.$store.dispatch('setCryptEnable', true);
       // Because the "key input" is an async behavior,
       // we need to remember what to do after it's done.
       // Any better method ?
       this.$store.dispatch('setCryptOP', { name: name, path: path });
+      this.$store.dispatch('setCryptKey', '');
+      this.$store.dispatch('setCryptEnable', true);
+    },
+    clearKeyPromptState() {
+      this.$store.dispatch('setCryptKey', '');
+      this.$store.dispatch('setCryptOP', { name: null, path: null });
     },
     async onKeyPromptDone(key) {
       const name = this.$store.state.Editor.crypt.op.name;
       const path = this.$store.state.Editor.crypt.op.path;
 
       if (key === null || key === '') {
-        this.$store.dispatch('setCryptOP', { name: null, path: null });
+        this.clearKeyPromptState();
         return;
       }
 
       // Opening encrypted files and saving with a new key resume here.
       if (name === 'open') {
-        this.readFile(path, key);
+        await this.openEncryptedFile(path, key);
       } else if (name === 'save') {
-        const result = await this.writeFile(path, key);
-        if (result) {
-          this.$store.dispatch('initFilePath', path);
-          this.editor.clearHistory();
-        }
+        await this.saveEncryptedFile(path, key);
       } else {
         const err = new UnexpectedStateError('crypt.op.name', name);
         openDialog('error', err.toString());
       }
-      this.$store.dispatch('setCryptOP', { name: null, path: null });
+      this.clearKeyPromptState();
     },
   },
 };

--- a/src/services/active-document.js
+++ b/src/services/active-document.js
@@ -1,0 +1,14 @@
+export const replaceActiveDocument = ({ editor, store, path, content }) => {
+  editor.setValue(content);
+  markActiveDocumentSaved({ editor, store, path });
+};
+
+export const markActiveDocumentSaved = ({ editor, store, path }) => {
+  store.dispatch('initFilePath', path);
+  editor.clearHistory();
+};
+
+export const clearActiveDocument = ({ editor, store }) => {
+  editor.clean();
+  store.dispatch('initFilePath', '');
+};

--- a/src/services/app-menu.js
+++ b/src/services/app-menu.js
@@ -62,8 +62,20 @@ export default {
       id: 'edit',
       label: 'Edit',
       submenu: [
-        { label: 'Undo', accelerator: 'CmdOrCtrl+Z', selector: 'undo:' },
-        { label: 'Redo', accelerator: 'CmdOrCtrl+Y', selector: 'redo:' },
+        {
+          label: 'Undo',
+          accelerator: 'CmdOrCtrl+Z',
+          click() {
+            AppMenuController.undo();
+          },
+        },
+        {
+          label: 'Redo',
+          accelerator: 'CmdOrCtrl+Y',
+          click() {
+            AppMenuController.redo();
+          },
+        },
         { type: 'separator' },
         { label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
         { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },

--- a/src/services/editor-commands.js
+++ b/src/services/editor-commands.js
@@ -1,0 +1,10 @@
+import { EventBus } from '@/shared/event-bus';
+
+export const registerEditorCommands = ({ undo, redo, newFile, openFile, saveFile, saveAs }) => {
+  EventBus.$on('undo', undo);
+  EventBus.$on('redo', redo);
+  EventBus.$on('newFile', newFile);
+  EventBus.$on('openFile', openFile);
+  EventBus.$on('saveFile', saveFile);
+  EventBus.$on('saveAs', saveAs);
+};

--- a/src/services/file-operation.js
+++ b/src/services/file-operation.js
@@ -1,0 +1,96 @@
+import filesystem from '@/adapters/filesystem';
+import { getSavePath, getSelectedResult, openDialog } from '@/adapters/electron';
+
+export const selectDocumentSavePath = () => {
+  return getSavePath([
+    { name: 'Markdown file', extensions: ['md'] },
+    { name: 'Text file', extensions: ['txt'] },
+    { name: 'Mii file', extensions: ['mii'] },
+  ]);
+};
+
+const openFile = ({ path, currentPath, key = null, onOpened }) => {
+  return new Promise((resolve) => {
+    if (currentPath === path) {
+      getSelectedResult({
+        title: '',
+        type: 'warning',
+        buttons: ['Yes'],
+        message: path,
+        detail: 'This file is already open.',
+      });
+      resolve(false);
+      return;
+    }
+
+    try {
+      filesystem.readFile(
+        path,
+        (err, content) => {
+          if (err === null) {
+            onOpened(content);
+            resolve(true);
+            return;
+          }
+
+          openDialog('error', err.toString());
+          resolve(false);
+        },
+        key,
+      );
+    } catch (e) {
+      openDialog('error', e.toString());
+      resolve(false);
+    }
+  });
+};
+
+export const openPlainFile = ({ path, currentPath, onOpened }) => {
+  return openFile({ path, currentPath, onOpened });
+};
+
+export const openEncryptedFile = ({ path, currentPath, key, onOpened }) => {
+  return openFile({ path, currentPath, key, onOpened });
+};
+
+const saveFile = ({ path, content, key = null, onSaved = () => {} }) => {
+  return new Promise((resolve) => {
+    try {
+      filesystem.writeFile(
+        path,
+        content,
+        (err) => {
+          if (err) {
+            openDialog('error', err.toString());
+            resolve(false);
+            return;
+          }
+
+          onSaved();
+          resolve(true);
+        },
+        key,
+      );
+    } catch (e) {
+      openDialog('error', e.toString());
+      resolve(false);
+    }
+  });
+};
+
+export const savePlainFile = ({ path, content }) => {
+  return saveFile({ path, content });
+};
+
+export const saveEncryptedFile = ({ path, content, key = null }) => {
+  return saveFile({
+    path,
+    content,
+    key,
+    onSaved: () => {
+      if (key !== null) {
+        filesystem.updateKey(key);
+      }
+    },
+  });
+};

--- a/src/services/render-pipeline.js
+++ b/src/services/render-pipeline.js
@@ -1,0 +1,21 @@
+import Markdown from '@/adapters/markdown.js';
+
+export default class RenderPipeline {
+  constructor(renderer = new Markdown()) {
+    this.renderer = renderer;
+    this.renderSeq = 0;
+  }
+
+  async requestRender(source, publish) {
+    const seq = ++this.renderSeq;
+    const html = await this.renderer.render(source);
+
+    if (seq === this.renderSeq) {
+      publish(html);
+    }
+  }
+
+  discardPendingResults() {
+    this.renderSeq++;
+  }
+}


### PR DESCRIPTION
## Summary

- Extract active document state transitions, file operation orchestration, render sequencing, and editor command registration into focused services.
- Re-prompt for an encryption key when saving an existing `.mii` file without a cached key.
- Route native menu Undo/Redo through the same command path as toolbar actions.
- Tighten unsupported drop extension handling and update architecture guidance for the new editor boundaries.

## Validation

- `npm run lint`
- `git diff --cached --check`
- Manual Electron checks for fenced-code preview rendering, keyboard Undo/Redo, paste fallback, and unsupported drag-drop handling.