### PR TITLE
Add editor empty state flow

### DIFF
--- a/src/adapters/editor.js
+++ b/src/adapters/editor.js
@@ -90,6 +90,10 @@ export default class Editor {
     return this.cm.isClean();
   }
 
+  getDocLength() {
+    return this.view.state.doc.length;
+  }
+
   clearHistory() {
     this.cm.markClean();
     this.createView(this.cm.getValue());

--- a/src/adapters/electron.js
+++ b/src/adapters/electron.js
@@ -88,6 +88,11 @@ export const checkedMenuItem = (menuId, state) => {
   if (menuItem) menuItem.checked = state;
 };
 
+export const enableMenuItem = (menuId, state) => {
+  const menuItem = menuInstance && menuInstance.getMenuItemById(menuId);
+  if (menuItem) menuItem.enabled = state;
+};
+
 export const setThemeSource = (theme) => {
   nativeTheme.themeSource = theme;
 };

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -6,6 +6,22 @@
         <textarea ref="editor" v-model="code" />
       </div>
       <div v-if="isPreview == true" class="preview"><div class="markdown-body" v-html="htmlCode" /></div>
+      <div v-if="showEmptyState" class="empty-state">
+        <div class="empty-state__panel">
+          <h2 class="empty-state__title">What would you like to do?</h2>
+          <div class="empty-state__actions">
+            <button
+              type="button"
+              class="empty-state__button empty-state__button--primary"
+              @click="activateEmptyStatePrimaryAction"
+            >
+              Start writing
+            </button>
+            <button type="button" class="empty-state__button" @click="openFile">Open file...</button>
+          </div>
+          <p class="empty-state__hint">Drop .md / .txt / .mii to open</p>
+        </div>
+      </div>
     </div>
     <DropField @open-file-path="openFilePath" />
     <KeyPrompt @done="onKeyPromptDone" />
@@ -55,20 +71,51 @@ export default {
       htmlCode: '',
       saveTimer: -1,
       pendingCloseTabId: null,
+      // Live emptiness signal: state.Editor.code lags typing by a 200ms debounce
+      // and is global, so the empty state reads this instead to hide on the first keystroke.
+      isActiveDocEmpty: true,
+      emptyStateTabIds: [],
     };
   },
   computed: {
     path() {
       return this.$store.getters.filePath;
     },
+    showEmptyState() {
+      return !this.cryptEnable && (this.hasNoTabs || this.shouldShowActiveTabEmptyState);
+    },
+    canUsePreview() {
+      return !this.showEmptyState && this.activeTabId != null;
+    },
+    hasNoTabs() {
+      return this.tabs.length === 0;
+    },
+    shouldShowActiveTabEmptyState() {
+      return (
+        this.activeTabId != null &&
+        this.emptyStateTabIds.includes(this.activeTabId) &&
+        !this.path &&
+        this.isActiveDocEmpty
+      );
+    },
     ...mapState({
       code: (state) => state.Editor.code,
       isPreview: (state) => state.Editor.isPreview,
       tabs: (state) => state.Editor.tabs,
       activeTabId: (state) => state.Editor.activeTabId,
+      cryptEnable: (state) => state.Editor.crypt.enable,
     }),
   },
   watch: {
+    canUsePreview: {
+      handler: function (value) {
+        this.$store.dispatch('setCanPreview', value);
+        if (!value && this.isPreview) {
+          this.$store.dispatch('updateIsPreview', false);
+        }
+      },
+      immediate: true,
+    },
     isPreview: {
       handler: function (value) {
         if (!value) return;
@@ -93,6 +140,11 @@ export default {
       this.editor = new Editor(this.$refs.editor);
 
       this.editor.cm.on('change', () => {
+        const value = this.editor.cm.getValue();
+        this.isActiveDocEmpty = value.length === 0;
+        if (value.length > 0) {
+          this.dismissEmptyStateForActiveTab();
+        }
         this.onEditorCodeChange();
       });
 
@@ -116,7 +168,6 @@ export default {
         this.saveTimer = -1;
       });
 
-      createUntitledTab({ editor: this.editor, store: this.$store });
       this._beforeUnloadHandler = (e) => this.confirmWindowClose(e);
       window.addEventListener('beforeunload', this._beforeUnloadHandler);
       this.onEditorReady();
@@ -153,7 +204,7 @@ export default {
       const newCode = this.editor.cm.getValue();
       this.$store.dispatch('updateCode', newCode);
 
-      if (newCode && this.isPreview) {
+      if (this.isPreview) {
         this.renderPreview(newCode);
       }
     }, 200),
@@ -165,22 +216,26 @@ export default {
     syncActiveDocumentView() {
       this.syncUndoRedoState(this.editor.cm);
       const current = this.editor.cm.getValue();
+      this.isActiveDocEmpty = current.length === 0;
       this.$store.dispatch('updateCode', current);
       this.renderPipeline.discardPendingResults();
       this.htmlCode = '';
-      if (this.isPreview) {
+      if (this.isPreview && this.canUsePreview) {
         this.renderPreview(current);
       }
-      this.editor.focus();
+      if (this.activeTabId != null) {
+        this.editor.focus();
+      }
     },
     async onTabSelect(tabId) {
       if (activateTab({ editor: this.editor, store: this.$store, tabId })) {
         this.syncActiveDocumentView();
-      } else {
+      } else if (this.activeTabId != null) {
         this.editor.focus();
       }
     },
     async onTabClose(tabId) {
+      if (tabId == null) return;
       // Activate the target tab first so the user sees what saveModifyFile asks about.
       await this.onTabSelect(tabId);
       const canContinue = await this.saveModifyFile();
@@ -190,6 +245,7 @@ export default {
       }
       if (!canContinue) return;
       removeTab({ editor: this.editor, store: this.$store, tabId });
+      this.emptyStateTabIds = this.emptyStateTabIds.filter((id) => id !== tabId);
       this.syncActiveDocumentView();
     },
     cycleTab(step) {
@@ -222,8 +278,22 @@ export default {
       return response !== 2;
     },
     newFile() {
-      createUntitledTab({ editor: this.editor, store: this.$store });
+      const id = createUntitledTab({ editor: this.editor, store: this.$store });
+      this.emptyStateTabIds = [...this.emptyStateTabIds, id];
       this.syncActiveDocumentView();
+    },
+    activateEmptyStatePrimaryAction() {
+      if (this.hasNoTabs) {
+        createUntitledTab({ editor: this.editor, store: this.$store });
+        this.syncActiveDocumentView();
+        return;
+      }
+
+      this.dismissEmptyStateForActiveTab();
+      this.editor.focus();
+    },
+    dismissEmptyStateForActiveTab() {
+      this.emptyStateTabIds = this.emptyStateTabIds.filter((id) => id !== this.activeTabId);
     },
     async openFile() {
       const files = showFileOpenDialog();
@@ -279,6 +349,8 @@ export default {
       this.syncActiveDocumentView();
     },
     async saveFile() {
+      if (this.activeTabId == null) return false;
+
       const isNewFile = !this.path;
       let savePath = this.path;
 
@@ -300,6 +372,8 @@ export default {
       return this.saveEncryptedFile(savePath, key, this.activeTabId);
     },
     async saveAs() {
+      if (this.activeTabId == null) return false;
+
       const savePath = selectDocumentSavePath();
 
       if (!savePath) return false;
@@ -405,6 +479,7 @@ export default {
         const saved = await this.saveEncryptedFile(path, key, op.tabId);
         if (saved && this.pendingCloseTabId === op.tabId) {
           removeTab({ editor: this.editor, store: this.$store, tabId: op.tabId });
+          this.emptyStateTabIds = this.emptyStateTabIds.filter((id) => id !== op.tabId);
           this.syncActiveDocumentView();
         }
       } else {
@@ -433,6 +508,7 @@ export default {
 
 .panes {
   display: flex;
+  position: relative;
   flex: 1;
   min-height: 0;
 }
@@ -444,6 +520,7 @@ export default {
 }
 
 .input {
+  position: relative;
   transition:
     flex-basis 0.2s ease-out,
     width 0.2s ease-out;
@@ -455,6 +532,100 @@ export default {
   :deep(.cm-editor) {
     width: 100%;
     height: 100%;
+  }
+}
+
+.empty-state {
+  display: flex;
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  pointer-events: auto;
+  background: var(--bg);
+  animation: empty-state-fade 0.15s ease-out;
+
+  &__panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    max-width: min(360px, 100%);
+    text-align: center;
+  }
+
+  &__title {
+    margin: 0;
+    color: var(--text);
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+  }
+
+  &__button {
+    min-height: 2.25rem;
+    padding: 0 1rem;
+    transition:
+      background-color 0.15s ease-out,
+      color 0.15s ease-out;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background-color: var(--bg-secondary);
+    color: var(--text);
+    font-size: $font-size-sm;
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+    user-select: none;
+    appearance: none;
+
+    &:hover:not(:disabled) {
+      background-color: var(--code-bg);
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: var(--focus-ring);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+
+    &--primary {
+      border-color: transparent;
+      background-color: var(--accent);
+      color: var(--accent-foreground);
+
+      &:hover:not(:disabled) {
+        background-color: var(--accent-hover);
+      }
+    }
+  }
+
+  &__hint {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: $font-size-sm;
+  }
+}
+
+@keyframes empty-state-fade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
   }
 }
 

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -140,9 +140,9 @@ export default {
       this.editor = new Editor(this.$refs.editor);
 
       this.editor.cm.on('change', () => {
-        const value = this.editor.cm.getValue();
-        this.isActiveDocEmpty = value.length === 0;
-        if (value.length > 0) {
+        const docLength = this.editor.getDocLength();
+        this.isActiveDocEmpty = docLength === 0;
+        if (docLength > 0) {
           this.dismissEmptyStateForActiveTab();
         }
         this.onEditorCodeChange();
@@ -204,7 +204,7 @@ export default {
       const newCode = this.editor.cm.getValue();
       this.$store.dispatch('updateCode', newCode);
 
-      if (this.isPreview) {
+      if (this.isPreview && this.canUsePreview) {
         this.renderPreview(newCode);
       }
     }, 200),

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -7,7 +7,7 @@
       <button :disabled="!canRedo" title="Redo" @click="redo">
         <font-awesome-icon icon="redo" />
       </button>
-      <button :title="isPreview ? 'Hide preview' : 'Show preview'" @click="togglePreview">
+      <button :disabled="!canPreview" :title="previewButtonTitle" @click="togglePreview">
         <font-awesome-icon v-if="isPreview" icon="eye" />
         <font-awesome-icon v-else icon="eye-slash" />
       </button>
@@ -30,7 +30,12 @@ export default {
       openToolbar: (state) => state.Editor.openToolbar,
       canUndo: (state) => state.Editor.canUndo,
       canRedo: (state) => state.Editor.canRedo,
+      canPreview: (state) => state.Editor.canPreview,
     }),
+    previewButtonTitle() {
+      if (!this.canPreview) return 'Preview unavailable';
+      return this.isPreview ? 'Hide preview' : 'Show preview';
+    },
   },
   watch: {},
   methods: {

--- a/src/services/active-document.js
+++ b/src/services/active-document.js
@@ -11,6 +11,7 @@ export const createUntitledTab = ({ editor, store }) => {
   const id = openDocuments.createSession();
   editor.openFresh('');
   store.dispatch('addTab', { id, path: '' });
+  return id;
 };
 
 export const openDocumentInNewTab = ({ editor, store, path, content, key = null }) => {
@@ -18,6 +19,7 @@ export const openDocumentInNewTab = ({ editor, store, path, content, key = null 
   const id = openDocuments.createSession(key);
   editor.openFresh(content);
   store.dispatch('addTab', { id, path });
+  return id;
 };
 
 export const activateTab = ({ editor, store, tabId }) => {
@@ -52,7 +54,7 @@ export const removeTab = ({ editor, store, tabId }) => {
     }
   }
 
-  createUntitledTab({ editor, store });
+  editor.openFresh('');
 };
 
 // A clean (non-dirty) tab holding `path` is stale once another tab saves over

--- a/src/services/app-menu-controller.js
+++ b/src/services/app-menu-controller.js
@@ -43,6 +43,7 @@ const AppMenuController = {
     EventBus.$emit('prevTab');
   },
   togglePreview() {
+    if (!store.state.Editor.canPreview) return;
     store.dispatch('updateIsPreview', !this.isOpenPreview());
   },
   toggleToolbar() {

--- a/src/services/app-menu.js
+++ b/src/services/app-menu.js
@@ -1,6 +1,7 @@
 import {
   setApplicationMenu,
   checkedMenuItem,
+  enableMenuItem,
   setupContextMenu as setupNativeContextMenu,
   setThemeSource,
   setWindowAlwaysOnTop,
@@ -117,6 +118,7 @@ export default {
           label: 'Toggle Preview Panel',
           type: 'checkbox',
           checked: store.state.Editor.isPreview,
+          enabled: store.state.Editor.canPreview,
           click() {
             AppMenuController.togglePreview();
           },
@@ -250,6 +252,8 @@ export default {
     store.subscribe((mutation, state) => {
       if (mutation.type === 'UPDATE_ISPREVIEW') {
         checkedMenuItem('toggle_preview_panel', state.Editor.isPreview);
+      } else if (mutation.type === 'SET_CAN_PREVIEW') {
+        enableMenuItem('toggle_preview_panel', state.Editor.canPreview);
       } else if (mutation.type === 'TOGGLE_TOOLBAR') {
         checkedMenuItem('toggle_toolbar', state.Editor.openToolbar);
       }

--- a/src/store/modules/Editor.js
+++ b/src/store/modules/Editor.js
@@ -4,6 +4,7 @@ const state = {
   openToolbar: true,
   canUndo: false,
   canRedo: false,
+  canPreview: false,
   tabs: [],
   activeTabId: null,
   crypt: {
@@ -39,6 +40,9 @@ const mutations = {
   SET_CAN_REDO(state, bool) {
     state.canRedo = bool;
   },
+  SET_CAN_PREVIEW(state, bool) {
+    state.canPreview = bool;
+  },
   SET_CRYPT_ENABLE(state, bool) {
     state.crypt.enable = bool;
   },
@@ -56,6 +60,9 @@ const mutations = {
   },
   REMOVE_TAB(state, id) {
     state.tabs = state.tabs.filter((t) => t.id !== id);
+    if (state.activeTabId === id) {
+      state.activeTabId = state.tabs[0]?.id ?? null;
+    }
   },
   SET_ACTIVE_TAB(state, id) {
     if (!findTab(state, id)) return;
@@ -98,6 +105,9 @@ const actions = {
   },
   setCanRedo({ commit }, bool) {
     commit('SET_CAN_REDO', bool);
+  },
+  setCanPreview({ commit }, bool) {
+    commit('SET_CAN_PREVIEW', bool);
   },
   setCryptEnable({ commit }, bool) {
     commit('SET_CRYPT_ENABLE', bool);

--- a/src/store/modules/Editor.js
+++ b/src/store/modules/Editor.js
@@ -61,7 +61,7 @@ const mutations = {
   REMOVE_TAB(state, id) {
     state.tabs = state.tabs.filter((t) => t.id !== id);
     if (state.activeTabId === id) {
-      state.activeTabId = state.tabs[0]?.id ?? null;
+      state.activeTabId = null;
     }
   },
   SET_ACTIVE_TAB(state, id) {


### PR DESCRIPTION
## Summary

- Add an empty state for the no-tab state and newly created empty tabs.
- Use English empty-state copy: "What would you like to do?", "Start writing", "Open file...", and "Drop .md / .txt / .mii to open".
- Let users start writing or open an existing file from the empty state without creating a preview-only view.
- Disable preview toggling while the empty state is active across the toolbar, native View menu, and controller entry point.
- Keep the last-tab-close path as a true no-tab state and guard save actions when there is no active tab.

## Validation

- `git diff --check`
- `node_modules/.bin/vue-cli-service lint --no-fix`
- `npm run build`
- Manual Electron verification: a newly created empty tab disables the toolbar preview button and `View > Toggle Preview Panel`, then re-enables both after starting the document.