### PR TITLE
Improve UI accessibility and layout polish

### DIFF
--- a/src/assets/style/Settings/_variables.scss
+++ b/src/assets/style/Settings/_variables.scss
@@ -21,3 +21,5 @@ $line-height-base:             1.8;
 $toolbar-width:     3rem;
 $tabbar-height:     2.25rem;
 $content-max-width: 46rem;
+$document-padding-block: 3rem;
+$document-padding-inline: 1.5rem;

--- a/src/assets/style/Vendor/_codemirror.scss
+++ b/src/assets/style/Vendor/_codemirror.scss
@@ -19,7 +19,7 @@
   .cm-content {
     max-width: $content-max-width;
     margin: 0 auto;
-    padding: 3rem 1.5rem 50vh;
+    padding: $document-padding-block $document-padding-inline 50vh;
   }
 
   .cm-line {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -637,7 +637,8 @@ export default {
   .markdown-body {
     max-width: $content-max-width;
     margin: 0 auto;
-    padding: 3rem 1.5rem;
+    padding: $document-padding-block $document-padding-inline 50vh;
+    line-height: $line-height-base;
   }
 }
 </style>

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -8,7 +8,7 @@
       <div v-if="isPreview == true" class="preview"><div class="markdown-body" v-html="htmlCode" /></div>
       <div v-if="showEmptyState" class="empty-state">
         <div class="empty-state__panel">
-          <h2 class="empty-state__title">What would you like to do?</h2>
+          <h2 class="empty-state__title">Start a document</h2>
           <div class="empty-state__actions">
             <button
               type="button"
@@ -17,9 +17,9 @@
             >
               Start writing
             </button>
-            <button type="button" class="empty-state__button" @click="openFile">Open file...</button>
+            <button type="button" class="empty-state__button" @click="openFile">Open file&hellip;</button>
           </div>
-          <p class="empty-state__hint">Drop .md / .txt / .mii to open</p>
+          <p class="empty-state__hint">Drop .md, .txt, or .mii files to open</p>
         </div>
       </div>
     </div>
@@ -540,9 +540,9 @@ export default {
   position: absolute;
   z-index: 1;
   inset: 0;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  padding: 1.5rem;
+  padding: clamp(5rem, 24vh, 9rem) 1.5rem 1.5rem;
   pointer-events: auto;
   background: var(--bg);
   animation: empty-state-fade 0.15s ease-out;
@@ -571,6 +571,7 @@ export default {
   }
 
   &__button {
+    min-width: 7rem;
     min-height: 2.25rem;
     padding: 0 1rem;
     transition:

--- a/src/components/TabBar.vue
+++ b/src/components/TabBar.vue
@@ -95,8 +95,7 @@ export default {
     },
     ariaLabelFor(tab) {
       const label = this.labelFor(tab);
-      const state = tab.id === this.activeTabId ? 'selected' : 'not selected';
-      return tab.isDirty ? `${label}, unsaved changes, ${state}` : `${label}, ${state}`;
+      return tab.isDirty ? `${label}, unsaved changes` : label;
     },
     closeLabelFor(tab) {
       const label = this.labelFor(tab);

--- a/src/components/TabBar.vue
+++ b/src/components/TabBar.vue
@@ -6,9 +6,10 @@
           v-for="tab in tabs"
           :key="tab.id"
           :ref="tab.id === activeTabId ? 'activeTab' : undefined"
+          :aria-label="ariaLabelFor(tab)"
           :aria-selected="tab.id === activeTabId"
-          :class="{ active: tab.id === activeTabId, dragging: tab.id === draggingTabId }"
-          :title="tab.path || labelFor(tab)"
+          :class="{ active: tab.id === activeTabId, dirty: tab.isDirty, dragging: tab.id === draggingTabId }"
+          :title="titleFor(tab)"
           class="tab"
           role="tab"
           draggable="true"
@@ -28,13 +29,13 @@
         >
           <span class="tab-label">{{ labelFor(tab) }}</span>
           <span v-if="tab.isDirty" class="dirty-dot" aria-hidden="true" />
-          <button class="close-btn" :aria-label="'Close ' + labelFor(tab)" @click.stop="$emit('close', tab.id)">
+          <button type="button" class="close-btn" :aria-label="closeLabelFor(tab)" @click.stop="$emit('close', tab.id)">
             <font-awesome-icon icon="xmark" />
           </button>
         </div>
       </div>
     </div>
-    <button class="new-tab-btn" aria-label="New tab" @click="$emit('new-tab')">
+    <button type="button" class="new-tab-btn" aria-label="New tab" @click="$emit('new-tab')">
       <font-awesome-icon icon="plus" />
     </button>
   </div>
@@ -87,6 +88,19 @@ export default {
   methods: {
     labelFor(tab) {
       return tab.path ? this.basename(tab.path) : 'Untitled-' + tab.id;
+    },
+    titleFor(tab) {
+      const label = tab.path || this.labelFor(tab);
+      return tab.isDirty ? `${label} - Unsaved changes` : label;
+    },
+    ariaLabelFor(tab) {
+      const label = this.labelFor(tab);
+      const state = tab.id === this.activeTabId ? 'selected' : 'not selected';
+      return tab.isDirty ? `${label}, unsaved changes, ${state}` : `${label}, ${state}`;
+    },
+    closeLabelFor(tab) {
+      const label = this.labelFor(tab);
+      return tab.isDirty ? `Close ${label} with unsaved changes` : `Close ${label}`;
     },
     basename(path) {
       return path.split(/[\\/]/).pop() || path;
@@ -216,7 +230,7 @@ export default {
   flex-shrink: 0;
   align-items: center;
   gap: 0.25rem;
-  padding: 0 0.5rem 0 0.75rem;
+  padding: 0 0.25rem 0 0.75rem;
   cursor: pointer;
   border-right: 1px solid var(--border);
   color: var(--text-muted);
@@ -237,6 +251,10 @@ export default {
   &.active {
     background: var(--bg);
     color: var(--text);
+  }
+
+  &.dirty .tab-label {
+    font-weight: 600;
   }
 
   &.dragging {
@@ -265,10 +283,10 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
+  width: 28px;
+  height: 28px;
   flex-shrink: 0;
-  border-radius: 4px;
+  border-radius: 6px;
   color: var(--text-muted);
   transition:
     background-color 0.15s ease-out,
@@ -277,6 +295,11 @@ export default {
   &:hover {
     background: var(--border);
     color: var(--text);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
   }
 
   .svg-inline--fa {
@@ -289,7 +312,7 @@ export default {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: $tabbar-height;
+  width: 2.5rem;
   color: var(--text-muted);
   transition:
     background-color 0.15s ease-out,
@@ -298,6 +321,11 @@ export default {
   &:hover {
     background: var(--code-bg);
     color: var(--text);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: inset var(--focus-ring);
   }
 
   .svg-inline--fa {

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -1,13 +1,19 @@
 <template>
   <div :class="{ open: openToolbar }" class="toolbar">
     <div class="menu">
-      <button :disabled="!canUndo" title="Undo" @click="undo">
+      <button type="button" :disabled="!canUndo" aria-label="Undo" title="Undo" @click="undo">
         <font-awesome-icon icon="undo" />
       </button>
-      <button :disabled="!canRedo" title="Redo" @click="redo">
+      <button type="button" :disabled="!canRedo" aria-label="Redo" title="Redo" @click="redo">
         <font-awesome-icon icon="redo" />
       </button>
-      <button :disabled="!canPreview" :title="previewButtonTitle" @click="togglePreview">
+      <button
+        type="button"
+        :disabled="!canPreview"
+        :aria-label="previewButtonTitle"
+        :title="previewButtonTitle"
+        @click="togglePreview"
+      >
         <font-awesome-icon v-if="isPreview" icon="eye" />
         <font-awesome-icon v-else icon="eye-slash" />
       </button>
@@ -83,8 +89,8 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 36px;
+  height: 36px;
   margin: 0 auto;
   transition:
     background-color 0.15s ease-out,
@@ -99,6 +105,11 @@ button {
   &:hover:not(:disabled) {
     background: var(--code-bg);
     color: var(--text);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
   }
 
   &:disabled {


### PR DESCRIPTION
## Summary
- Enlarged toolbar and tab hit targets, added accessible labels, and made unsaved tab state clearer.
- Refined the empty editor state copy and spacing to make the primary actions easier to scan.
- Shared document spacing tokens between the editor and preview so split-view reading feels more aligned.

## Validation
- npm run lint
- npm run lint:scss
- npm run electron:serve