### PR TITLE
Optimize npm package metadata

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+# Prevent broken global fsmonitor output from being parsed as staged file names.
+GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.fsmonitor GIT_CONFIG_VALUE_0=false lint-staged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ npm run format:scss      # stylelint --fix
 
 There is no test suite. Verification = `npm run lint` + confirming the app still launches via `electron:serve`.
 
-`npm run serve` / `npm run build` exist but target the browser; the renderer imports Node builtins (`fs`, `crypto`) directly, so the app only truly runs under Electron.
+Browser-only `npm run serve` / `npm run build` scripts are intentionally not defined; the renderer imports Node builtins (`fs`, `crypto`) directly, so the app only truly runs under Electron.
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,11 @@
         "core-js": "^3.49.0",
         "debounce": "^3.0.0",
         "markdown-it": "^14.2.0",
+        "markdown-it-anchor": "^9.2.0",
         "markdown-it-checkbox": "^1.1.0",
+        "markdown-it-deflist": "^3.0.1",
         "markdown-it-footnote": "^4.0.0",
+        "markdown-it-multimd-table": "^4.2.3",
         "normalize.css": "^8.0.1",
         "shiki": "^4.2.0",
         "vue": "^3.5.38",
@@ -37,7 +40,6 @@
         "@vue/cli-plugin-eslint": "^5.0.9",
         "@vue/cli-service": "^5.0.9",
         "@vue/compiler-sfc": "^3.5.38",
-        "babel-eslint": "^10.1.0",
         "electron": "^42.4.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.8",
@@ -45,13 +47,9 @@
         "eslint-plugin-vue": "^10.9.2",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.7",
-        "markdown-it-anchor": "^9.2.0",
-        "markdown-it-deflist": "^3.0.1",
-        "markdown-it-multimd-table": "^4.2.3",
         "prettier": "^3.8.4",
         "sass": "^1.100.0",
         "sass-loader": "^17.0.0",
-        "style-loader": "^4.0.0",
         "stylelint": "^17.13.0",
         "stylelint-config-property-sort-order-smacss": "^11.2.0",
         "stylelint-config-recommended": "^18.0.0",
@@ -3460,7 +3458,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3468,7 +3465,6 @@
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3489,7 +3485,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -6385,28 +6380,6 @@
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
-      }
     },
     "node_modules/babel-loader": {
       "version": "8.4.1",
@@ -10257,16 +10230,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -14015,7 +13978,6 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.2.0.tgz",
       "integrity": "sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==",
-      "dev": true,
       "license": "Unlicense",
       "peerDependencies": {
         "@types/markdown-it": "*",
@@ -14035,7 +13997,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-3.0.1.tgz",
       "integrity": "sha512-pPtXxihDMi9jrwLLQ+Jra/FM20F/FFJWiVjXf0Js6Lwp7LFj+MuK6cUJNMVTRL+n9d/JqF4MEqYZwSMgVodK5g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/markdown-it-footnote": {
@@ -14048,7 +14009,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/markdown-it-multimd-table/-/markdown-it-multimd-table-4.2.3.tgz",
       "integrity": "sha512-KepCr2OMJqm7IT6sOIbuqHGe+NERhgy66XMrc5lo6dHW7oaPzMDtYwR1EGwK16/blb6mCSg4jqityOe0o/H7HA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/markdown-it/node_modules/entities": {
@@ -19298,23 +19258,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/style-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
-      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.27.0"
       }
     },
     "node_modules/style-mod": {

--- a/package.json
+++ b/package.json
@@ -5,15 +5,13 @@
   "description": "A Simple Markdown Editor",
   "author": "hiro <hiro0218@gmail.com>",
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "electron:build": "vue-cli-service electron:build",
     "electron:serve": "vue-cli-service electron:serve",
     "format:scss": "stylelint --fix \"src/**/*.scss\"",
     "lint:scss": "stylelint \"src/**/*.scss\"",
     "postinstall": "electron-builder install-app-deps",
-    "postuninstall": "electron-builder install-app-deps"
+    "prepare": "husky"
   },
   "main": "background.js",
   "dependencies": {
@@ -30,8 +28,11 @@
     "core-js": "^3.49.0",
     "debounce": "^3.0.0",
     "markdown-it": "^14.2.0",
+    "markdown-it-anchor": "^9.2.0",
     "markdown-it-checkbox": "^1.1.0",
+    "markdown-it-deflist": "^3.0.1",
     "markdown-it-footnote": "^4.0.0",
+    "markdown-it-multimd-table": "^4.2.3",
     "normalize.css": "^8.0.1",
     "shiki": "^4.2.0",
     "vue": "^3.5.38",
@@ -44,7 +45,6 @@
     "@vue/cli-plugin-eslint": "^5.0.9",
     "@vue/cli-service": "^5.0.9",
     "@vue/compiler-sfc": "^3.5.38",
-    "babel-eslint": "^10.1.0",
     "electron": "^42.4.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
@@ -52,13 +52,9 @@
     "eslint-plugin-vue": "^10.9.2",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.7",
-    "markdown-it-anchor": "^9.2.0",
-    "markdown-it-deflist": "^3.0.1",
-    "markdown-it-multimd-table": "^4.2.3",
     "prettier": "^3.8.4",
     "sass": "^1.100.0",
     "sass-loader": "^17.0.0",
-    "style-loader": "^4.0.0",
     "stylelint": "^17.13.0",
     "stylelint-config-property-sort-order-smacss": "^11.2.0",
     "stylelint-config-recommended": "^18.0.0",
@@ -71,11 +67,6 @@
     "url": "https://github.com/hiro0218/Miikun/issues"
   },
   "homepage": "https://github.com/hiro0218/Miikun#readme",
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "license": "MIT",
   "lint-staged": {
     "**/*.{js,vue}": [


### PR DESCRIPTION
## Summary

This PR cleans up npm metadata and dependency categorization for the Electron app.

Changes include:
- Remove browser-only `serve` and `build` scripts that are not valid for this Electron renderer setup.
- Remove unused `postuninstall`, `babel-eslint`, and `style-loader` entries.
- Move runtime Markdown plugins from `devDependencies` to `dependencies`.
- Add a Husky v9 pre-commit hook that runs `lint-staged` while disabling broken local fsmonitor output for that hook invocation.
- Update the agent guidance to match the removed browser-only npm scripts.

## Why

The package metadata contained scripts and dependencies that were either unused or misleading for the current Electron-only workflow. The Husky configuration also mixed the old package.json hook style with Husky v9, so the pre-commit entrypoint was not represented in the tracked `.husky` layout.

## Impact

The supported Electron workflow remains unchanged. The package lock now reflects fewer unused dev-only packages, and runtime Markdown plugins are declared in the correct dependency section.

## Validation

- `npm install --package-lock-only --ignore-scripts`
- `npm prune --ignore-scripts`
- `npm ls --depth=0`
- `npm run lint`
- `npm run lint:scss`
- `sh .husky/_/pre-commit`
- `npm run electron:build`
- `npm run prepare`

Notes:
- `npm` still reports existing engine warnings for the current local Node `v22.12.0`.
- The Electron build completes, with macOS code signing skipped because no local signing identity is configured.