### PR TITLE
Improve Markdown toolbar controls

### DIFF
--- a/src/adapters/editor.js
+++ b/src/adapters/editor.js
@@ -21,6 +21,9 @@ const markdownHighlight = HighlightStyle.define([
   { tag: tags.quote, color: 'var(--text-muted)' },
   { tag: [tags.processingInstruction, tags.meta, tags.labelName, tags.contentSeparator], color: 'var(--text-muted)' },
 ]);
+const EDITABLE_HEADING_LEVELS = [0, 1, 2, 3];
+const HEADING_MARKER = /^(#{1,6})(?:\s+|$)/;
+const BULLET_MARKER = /^(\s*)[-*+]\s+/;
 
 export default class Editor {
   constructor(element) {
@@ -104,6 +107,74 @@ export default class Editor {
     this.cm.replaceRange(text, { line, ch }, { line, ch });
   }
 
+  setHeadingLevel(level) {
+    const headingLevel = Number(level);
+    if (!EDITABLE_HEADING_LEVELS.includes(headingLevel)) return false;
+
+    const { doc, selection } = this.view.state;
+    const selectedLineEnd = this.getSelectedLineEnd(selection.main, doc);
+    const fromLine = doc.lineAt(selection.main.from).number;
+    const toLine = doc.lineAt(selectedLineEnd).number;
+    const changes = [];
+
+    for (let lineNumber = fromLine; lineNumber <= toLine; lineNumber += 1) {
+      const change = this.getHeadingLineChange(doc.line(lineNumber), headingLevel);
+      if (change) changes.push(change);
+    }
+
+    if (changes.length > 0) {
+      this.view.dispatch({ changes });
+    }
+
+    this.view.focus();
+    return true;
+  }
+
+  toggleBold() {
+    const applied = this.toggleSelectionWrap(this.view, '**');
+    this.view.focus();
+    return applied;
+  }
+
+  insertLink() {
+    const selection = this.view.state.selection.main;
+    const selectedText = this.view.state.sliceDoc(selection.from, selection.to);
+    const label = selectedText || 'text';
+    const insert = `[${label}](url)`;
+    const selectionFrom = selectedText ? selection.from + label.length + 3 : selection.from + 1;
+    const selectionTo = selectedText ? selectionFrom + 3 : selectionFrom + label.length;
+
+    this.view.dispatch({
+      changes: {
+        from: selection.from,
+        to: selection.to,
+        insert,
+      },
+      selection: {
+        anchor: selectionFrom,
+        head: selectionTo,
+      },
+    });
+    this.view.focus();
+    return true;
+  }
+
+  toggleBulletList() {
+    const { doc, selection } = this.view.state;
+    const selectedLineEnd = this.getSelectedLineEnd(selection.main, doc);
+    const fromLine = doc.lineAt(selection.main.from).number;
+    const toLine = doc.lineAt(selectedLineEnd).number;
+    const changes = [];
+
+    for (let lineNumber = fromLine; lineNumber <= toLine; lineNumber += 1) {
+      changes.push(this.getBulletLineChange(doc.line(lineNumber)));
+    }
+
+    this.view.dispatch({ changes });
+    this.view.focus();
+    return true;
+  }
+
   createView(doc) {
     if (this.view) {
       this.view.destroy();
@@ -175,6 +246,51 @@ export default class Editor {
           changes: { from: fromPos, to: toPos, insert: text },
         });
       },
+      setHeadingLevel: (level) => this.setHeadingLevel(level),
+      toggleBold: () => this.toggleBold(),
+      insertLink: () => this.insertLink(),
+      toggleBulletList: () => this.toggleBulletList(),
+    };
+  }
+
+  getSelectedLineEnd(selection, doc) {
+    if (selection.to <= selection.from) return selection.to;
+
+    const endsAtLineBreak = doc.sliceString(selection.to - 1, selection.to) === '\n';
+    return endsAtLineBreak ? selection.to - 1 : selection.to;
+  }
+
+  getHeadingLineChange(line, level) {
+    const marker = line.text.match(HEADING_MARKER);
+    const currentMarker = marker ? marker[0] : '';
+    const nextMarker = level === 0 ? '' : `${'#'.repeat(level)} `;
+
+    if (currentMarker === nextMarker) return null;
+
+    return {
+      from: line.from,
+      to: line.from + currentMarker.length,
+      insert: nextMarker,
+    };
+  }
+
+  getBulletLineChange(line) {
+    const marker = line.text.match(BULLET_MARKER);
+
+    if (marker) {
+      const markerFrom = line.from + marker[1].length;
+      return {
+        from: markerFrom,
+        to: line.from + marker[0].length,
+        insert: '',
+      };
+    }
+
+    const indent = line.text.match(/^\s*/)[0];
+    return {
+      from: line.from + indent.length,
+      to: line.from + indent.length,
+      insert: '- ',
     };
   }
 

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -176,13 +176,19 @@ export default {
     onEditorReady() {
       // Native menu accelerators bypass the KeyPrompt overlay, so every command
       // is frozen here while a crypt operation is pending.
-      const guarded = (fn) => () => {
-        if (this.isKeyPromptOpen()) return;
-        fn();
+      const guarded = (fn) => {
+        return (...args) => {
+          if (this.isKeyPromptOpen()) return;
+          fn(...args);
+        };
       };
       registerEditorCommands({
         undo: guarded(() => this.editor.cm.undo()),
         redo: guarded(() => this.editor.cm.redo()),
+        setHeadingLevel: guarded((level) => this.editor.cm.setHeadingLevel(level)),
+        toggleBold: guarded(() => this.editor.cm.toggleBold()),
+        insertLink: guarded(() => this.editor.cm.insertLink()),
+        toggleBulletList: guarded(() => this.editor.cm.toggleBulletList()),
         newFile: guarded(() => this.newFile()),
         openFile: guarded(() => this.openFile()),
         saveFile: guarded(() => this.saveFile()),

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -1,22 +1,61 @@
 <template>
   <div :class="{ open: openToolbar }" class="toolbar">
-    <div class="menu">
-      <button type="button" :disabled="!canUndo" aria-label="Undo" title="Undo" @click="undo">
-        <font-awesome-icon icon="undo" />
-      </button>
-      <button type="button" :disabled="!canRedo" aria-label="Redo" title="Redo" @click="redo">
-        <font-awesome-icon icon="redo" />
-      </button>
-      <button
-        type="button"
-        :disabled="!canPreview"
-        :aria-label="previewButtonTitle"
-        :title="previewButtonTitle"
-        @click="togglePreview"
-      >
-        <font-awesome-icon v-if="isPreview" icon="eye" />
-        <font-awesome-icon v-else icon="eye-slash" />
-      </button>
+    <div class="menu" aria-label="Markdown toolbar">
+      <div class="menu-section">
+        <button type="button" :disabled="!canUndo" aria-label="Undo" title="Undo" @click="undo">
+          <font-awesome-icon icon="undo" />
+        </button>
+        <button type="button" :disabled="!canRedo" aria-label="Redo" title="Redo" @click="redo">
+          <font-awesome-icon icon="redo" />
+        </button>
+      </div>
+      <div class="menu-section">
+        <span :class="{ disabled: !canEditDocument }" class="heading-control">
+          <select
+            class="heading-select"
+            :disabled="!canEditDocument"
+            aria-label="Heading level"
+            title="Heading level"
+            @change="setHeadingLevel"
+          >
+            <option value="" disabled selected>H</option>
+            <option value="0">Text</option>
+            <option value="1">H1</option>
+            <option value="2">H2</option>
+            <option value="3">H3</option>
+          </select>
+          <font-awesome-icon class="heading-control__icon" icon="chevron-down" aria-hidden="true" />
+        </span>
+        <button type="button" :disabled="!canEditDocument" aria-label="Bold" title="Bold" @click="toggleBold">
+          <font-awesome-icon icon="bold" />
+        </button>
+        <button type="button" :disabled="!canEditDocument" aria-label="Link" title="Link" @click="insertLink">
+          <font-awesome-icon icon="link" />
+        </button>
+        <button
+          type="button"
+          :disabled="!canEditDocument"
+          aria-label="Bulleted list"
+          title="Bulleted list"
+          @click="toggleBulletList"
+        >
+          <font-awesome-icon icon="list-ul" />
+        </button>
+      </div>
+      <div class="menu-section">
+        <button
+          type="button"
+          :class="{ active: isPreview }"
+          :disabled="!canPreview"
+          :aria-label="previewButtonTitle"
+          :aria-pressed="isPreview"
+          :title="previewButtonTitle"
+          @click="togglePreview"
+        >
+          <font-awesome-icon v-if="isPreview" icon="eye" />
+          <font-awesome-icon v-else icon="eye-slash" />
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -37,7 +76,12 @@ export default {
       canUndo: (state) => state.Editor.canUndo,
       canRedo: (state) => state.Editor.canRedo,
       canPreview: (state) => state.Editor.canPreview,
+      activeTabId: (state) => state.Editor.activeTabId,
+      cryptEnable: (state) => state.Editor.crypt.enable,
     }),
+    canEditDocument() {
+      return this.activeTabId != null && !this.cryptEnable;
+    },
     previewButtonTitle() {
       if (!this.canPreview) return 'Preview unavailable';
       return this.isPreview ? 'Hide preview' : 'Show preview';
@@ -50,6 +94,22 @@ export default {
     },
     redo() {
       AppMenuController.redo();
+    },
+    setHeadingLevel(event) {
+      const { value } = event.target;
+      if (value !== '') {
+        AppMenuController.setHeadingLevel(Number(value));
+      }
+      event.target.value = '';
+    },
+    toggleBold() {
+      AppMenuController.toggleBold();
+    },
+    insertLink() {
+      AppMenuController.insertLink();
+    },
+    toggleBulletList() {
+      AppMenuController.toggleBulletList();
     },
     togglePreview() {
       AppMenuController.togglePreview();
@@ -66,14 +126,22 @@ export default {
   display: flex;
   flex-direction: column;
   width: 0;
+  min-height: 0;
   padding: 0.75rem 0;
   overflow: hidden;
   transition: width 0.2s ease-out;
   background: var(--bg-secondary);
 
   > .menu {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
     transition: opacity 0.15s ease-out;
     opacity: 0;
+    scrollbar-width: thin;
   }
 
   &.open {
@@ -85,10 +153,8 @@ export default {
   }
 }
 
-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+button,
+.heading-control {
   width: 36px;
   height: 36px;
   margin: 0 auto;
@@ -97,12 +163,31 @@ button {
     color 0.15s ease-out;
   border-radius: 8px;
   color: var(--text-muted);
+}
 
-  & + button {
-    margin-top: 0.5rem;
+.menu-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  & + & {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--border);
   }
+}
+
+button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   &:hover:not(:disabled) {
+    background: var(--code-bg);
+    color: var(--text);
+  }
+
+  &.active:not(:disabled) {
     background: var(--code-bg);
     color: var(--text);
   }
@@ -119,6 +204,51 @@ button {
 
   .svg-inline--fa {
     font-size: 14px;
+  }
+}
+
+.heading-control {
+  position: relative;
+  display: block;
+
+  &:hover:not(.disabled) {
+    background: var(--code-bg);
+    color: var(--text);
+  }
+
+  &.disabled {
+    opacity: 0.5;
+  }
+
+  &__icon {
+    position: absolute;
+    right: 6px;
+    bottom: 7px;
+    font-size: 8px;
+    pointer-events: none;
+  }
+}
+
+.heading-select {
+  width: 100%;
+  height: 100%;
+  padding: 0 0.5rem 0 0;
+  border-radius: inherit;
+  color: inherit;
+  font-size: $font-size-sm;
+  font-weight: 600;
+  text-align: center;
+  text-align-last: center;
+  cursor: pointer;
+  appearance: none;
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+  }
+
+  &:disabled {
+    cursor: default;
   }
 }
 </style>

--- a/src/plugins/fontawesome/index.js
+++ b/src/plugins/fontawesome/index.js
@@ -1,8 +1,19 @@
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faUndo, faRedo, faEye, faEyeSlash, faXmark, faPlus } from '@fortawesome/free-solid-svg-icons';
+import {
+  faBold,
+  faChevronDown,
+  faEye,
+  faEyeSlash,
+  faLink,
+  faListUl,
+  faPlus,
+  faRedo,
+  faUndo,
+  faXmark,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
-library.add(faUndo, faRedo, faEye, faEyeSlash, faXmark, faPlus);
+library.add(faUndo, faRedo, faEye, faEyeSlash, faXmark, faPlus, faBold, faLink, faListUl, faChevronDown);
 
 export default function setupFontAwesome(app) {
   app.component('FontAwesomeIcon', FontAwesomeIcon);

--- a/src/services/app-menu-controller.js
+++ b/src/services/app-menu-controller.js
@@ -21,6 +21,18 @@ const AppMenuController = {
   redo() {
     EventBus.$emit('redo');
   },
+  setHeadingLevel(level) {
+    EventBus.$emit('setHeadingLevel', level);
+  },
+  toggleBold() {
+    EventBus.$emit('toggleBold');
+  },
+  insertLink() {
+    EventBus.$emit('insertLink');
+  },
+  toggleBulletList() {
+    EventBus.$emit('toggleBulletList');
+  },
   newFile() {
     EventBus.$emit('newFile');
   },

--- a/src/services/editor-commands.js
+++ b/src/services/editor-commands.js
@@ -3,6 +3,10 @@ import { EventBus } from '@/shared/event-bus';
 export const registerEditorCommands = ({
   undo,
   redo,
+  setHeadingLevel,
+  toggleBold,
+  insertLink,
+  toggleBulletList,
   newFile,
   openFile,
   saveFile,
@@ -13,6 +17,10 @@ export const registerEditorCommands = ({
 }) => {
   EventBus.$on('undo', undo);
   EventBus.$on('redo', redo);
+  EventBus.$on('setHeadingLevel', setHeadingLevel);
+  EventBus.$on('toggleBold', toggleBold);
+  EventBus.$on('insertLink', insertLink);
+  EventBus.$on('toggleBulletList', toggleBulletList);
   EventBus.$on('newFile', newFile);
   EventBus.$on('openFile', openFile);
   EventBus.$on('saveFile', saveFile);


### PR DESCRIPTION
## Summary

- Add toolbar actions for heading levels, bold, links, and bulleted lists.
- Improve toolbar grouping, overflow behavior, and heading menu affordance.
- Make the preview control expose and display its toggle state.

## Validation

- `npm run lint`
- `npm run lint:scss`
- `npm run electron:serve` compiled successfully and launched the Electron app.