### PR TITLE
Clarify encrypted file password prompts

### DIFF
--- a/src/components/KeyPrompt.tsx
+++ b/src/components/KeyPrompt.tsx
@@ -9,6 +9,11 @@ export default function KeyPrompt({ onDone }) {
   const [title, setTitle] = useState('');
   const enable = store.state.Editor.crypt.enable;
   const key = store.state.Editor.crypt.key || '';
+  const operationName = store.state.Editor.crypt.op.name;
+  const placeholder =
+    operationName === 'open'
+      ? 'Enter the password to open the encrypted file.'
+      : 'Enter a password to encrypt the file.';
 
   useEffect(() => {
     if (!enable) return;
@@ -46,7 +51,7 @@ export default function KeyPrompt({ onDone }) {
             value={key}
             type="password"
             className="keyprompt-dialog__input"
-            placeholder="Enter a password to encrypt the file."
+            placeholder={placeholder}
             maxLength={50}
             onChange={(event) => store.dispatch('setCryptKey', event.target.value)}
           />

--- a/src/services/file-operation.ts
+++ b/src/services/file-operation.ts
@@ -5,7 +5,7 @@ export const selectDocumentSavePath = () => {
   return getSavePath([
     { name: 'Markdown file', extensions: ['md'] },
     { name: 'Text file', extensions: ['txt'] },
-    { name: 'Mii file', extensions: ['mii'] },
+    { name: 'Encrypted miikun file', extensions: ['mii'] },
   ]);
 };
 


### PR DESCRIPTION
## Summary
- Show a different password placeholder when opening an encrypted file versus saving one.
- Rename the .mii save dialog format label to make the encrypted-file behavior explicit.

## Validation
- npm run lint
- npm run typecheck
- Manual Electron validation for .mii save/open prompts and the encrypted-file save dialog label.